### PR TITLE
Fix for Siri and local DNS

### DIFF
--- a/dist/bond.js
+++ b/dist/bond.js
@@ -63,7 +63,7 @@ class Bond {
     }
     sendCommand(session, command, device) {
         this.sequence++;
-        let url = "https://" + this.id + ".local:4433/api/v1/device/" + (parseInt(device.propertyId) - 1) + "/device_property/" + device.propertyId + "/device_property_command/" + command.propertyId + "/run";
+        let url = "https://" + this.id + ":4433/api/v1/device/" + (parseInt(device.propertyId) - 1) + "/device_property/" + device.propertyId + "/device_property_command/" + command.propertyId + "/run";
         return request({
             method: 'GET',
             uri: url,

--- a/dist/index.js
+++ b/dist/index.js
@@ -126,6 +126,11 @@ class BondPlatform {
             bulb.getCharacteristic(Characteristic.On)
                 .on('set', function (value, callback) {
                 let command = bond.commandForName(device, "Light Toggle");
+                // Called to avoid toggling when the light is already in the requested state. (Workaround for Siri)
+                if (value == bulb.getCharacteristic(Characteristic.On).value) {
+                    callback();
+                    return;
+                }
                 bond.sendCommand(that.session, command, device)
                     .then(() => {
                     bulb.getCharacteristic(Characteristic.On).updateValue(value);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-bond",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A homebridge plugin to control your IR/RF devices via BOND.",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/bond.ts
+++ b/src/bond.ts
@@ -90,7 +90,7 @@ export class Bond {
 
   public sendCommand(session: Session, command: Command, device: Device): Promise<void> {
     this.sequence++;
-    let url = "https://" + this.id + ".local:4433/api/v1/device/" + (parseInt(device.propertyId) - 1) + "/device_property/" + device.propertyId + "/device_property_command/" + command.propertyId + "/run";
+    let url = "https://" + this.id + ":4433/api/v1/device/" + (parseInt(device.propertyId) - 1) + "/device_property/" + device.propertyId + "/device_property_command/" + command.propertyId + "/run";
 
     return request({
         method: 'GET',

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,11 @@ class BondPlatform {
         bulb.getCharacteristic(Characteristic.On)
           .on('set', function (value, callback) {
             let command = bond.commandForName(device, "Light Toggle");
+            // Called to avoid toggling when the light is already in the requested state. (Workaround for Siri)
+            if (value == bulb.getCharacteristic(Characteristic.On).value) {
+               callback();
+               return;
+            }
             bond.sendCommand(that.session, command, device)
               .then(() => {
               bulb.getCharacteristic(Characteristic.On).updateValue(value);


### PR DESCRIPTION
Two updates:
1) remove hardcoded ".local" pseudo-TLD. IMO this is best left to the system's resolver because though it is the common default, not everyone uses ".local". I tested this in a linux environment, not sure on Windows or MacOS, but my hunch is the behavior should be the same.

2) Added a check to prevent toggling a light if it's already in the requested state. This is a fix for Siri, because otherwise even if the light is in the requested state it will send an API call to Bond's servers, resulting in out-of-sync between the actual light and what HomeKit thinks the state of it is.


Also includes a minor version number bump to 0.2.1