### PR TITLE
Changing HomeKit name to use Bond name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { Observer } from './Observer';
 
 let Accessory: any;
 
-export default function (homebridge: any) {
+export default (homebridge: any) => {
   hap.Service = homebridge.hap.Service;
   hap.Characteristic = homebridge.hap.Characteristic;
   Accessory = homebridge.platformAccessory;
@@ -85,7 +85,7 @@ export class BondPlatform {
       return;
     }
 
-    const accessory = new Accessory(device.location + ' ' + device.name, hap.UUIDGen.generate(device.id.toString()));
+    const accessory = new Accessory(`${device.location} ${device.name}`, hap.UUIDGen.generate(device.id.toString()));
     accessory.context.device = device;
     accessory.reachable = true;
     accessory

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { Observer } from './Observer';
 
 let Accessory: any;
 
-export default function(homebridge: any) {
+export default function (homebridge: any) {
   hap.Service = homebridge.hap.Service;
   hap.Characteristic = homebridge.hap.Characteristic;
   Accessory = homebridge.platformAccessory;
@@ -85,7 +85,7 @@ export class BondPlatform {
       return;
     }
 
-    const accessory = new Accessory(device.location + ' ' + device.type, hap.UUIDGen.generate(device.id.toString()));
+    const accessory = new Accessory(device.location + ' ' + device.name, hap.UUIDGen.generate(device.id.toString()));
     accessory.context.device = device;
     accessory.reachable = true;
     accessory


### PR DESCRIPTION
This change makes it so we use the name of the Bond device you input into the Bond app, instead of using the internal device type code. 

So for instance "Bedroom CF" becomes "Bedroom Ceiling Fan" if that's the room and name you used inside the Bond app. 

