### PR TITLE
Feature dimmer up down

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![npm version](https://badge.fury.io/js/homebridge-bond.svg)](https://badge.fury.io/js/homebridge-bond)
+[![verified-by-homebridge](https://badgen.net/badge/homebridge/verified/purple)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins) [![npm version](https://badge.fury.io/js/homebridge-bond.svg)](https://badge.fury.io/js/homebridge-bond)
 
 # homebridge-bond
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,48 @@
+{
+  "pluginAlias": "Bond",
+  "pluginType": "platform",
+  "singular": true,
+  "schema": {
+    "type": "object",
+    "properties": {
+      "bonds": {
+        "title": "Bonds",
+        "type": "array",
+        "required": true,
+        "uniqueItems": true,
+        "items": {
+          "title": "Bond",
+          "type": "object",
+          "properties": {
+            "ip_address": {
+              "title": "IP Address",
+              "type": "string",
+              "required": true,
+              "description": "IP Address of your Bond."
+            },
+            "token": {
+              "title": "Bond Token",
+              "type": "string",
+              "required": true,
+              "description": "Can be found in the bond app by tapping your Bond device and looking for 'Local Token'."
+            }
+          }
+        }
+      },
+      "debug": {
+        "title": "Debug mode",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "description": "Turns on additional logging."
+      },
+      "include_dimmer": {
+        "title": "Include dimmer",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "description": "If dimming is a valid action on a device, it will be included as additional switch on the accessory. Since this is an odd solution to dimming, it's off by default."
+      }
+    }
+  }
+}

--- a/config.schema.json
+++ b/config.schema.json
@@ -18,13 +18,15 @@
               "title": "IP Address",
               "type": "string",
               "required": true,
-              "description": "IP Address of your Bond."
+              "description": "IP Address of your Bond.",
+              "placeholder": "e.g. 192.168.1.1"
             },
             "token": {
               "title": "Bond Token",
               "type": "string",
               "required": true,
-              "description": "Can be found in the bond app by tapping your Bond device and looking for 'Local Token'."
+              "description": "Can be found in the bond app by tapping your Bond device and looking for 'Local Token'.",
+              "placeholder": "e.g. fd3904894ff98f"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-bond",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "A homebridge plugin to control your Bond devices over the v2 API.",
   "license": "MIT",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-bond",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "A homebridge plugin to control your Bond devices over the v2 API.",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/BondApi.ts
+++ b/src/BondApi.ts
@@ -56,6 +56,14 @@ export class BondApi {
     return this.request(HTTPMethod.PUT, this.uri.action(device.id, Action.StartDimmer));
   }
 
+  public startIncreasingBrightness(device: Device): Promise<void> {
+    return this.request(HTTPMethod.PUT, this.uri.action(device.id, Action.StartIncreasingBrightness));
+  }
+
+  public startDecreasingBrightness(device: Device): Promise<void> {
+    return this.request(HTTPMethod.PUT, this.uri.action(device.id, Action.StartDecreasingBrightness));
+  }
+
   public stop(device: Device): Promise<void> {
     return this.request(HTTPMethod.PUT, this.uri.action(device.id, Action.Stop));
   }

--- a/src/enum/Action.ts
+++ b/src/enum/Action.ts
@@ -3,6 +3,8 @@ export enum Action {
   TurnOff = 'TurnOff',
   TurnOn = 'TurnOn',
   StartDimmer = 'StartDimmer',
+  StartIncreasingBrightness = 'StartIncreasingBrightness',
+  StartDecreasingBrightness = 'StartDecreasingBrightness',
   Stop = 'Stop',
   SetSpeed = 'SetSpeed',
   ToggleDirection = 'ToggleDirection',

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,6 +204,7 @@ export class BondPlatform {
                 if (dimmer === undefined) {
                   this.log(`${accessory.displayName} didn't have dimmer defined. define it now`);
                   dimmer = accessory.addService(hap.Service.Switch, `${accessory.displayName} Dimmer`);
+                  dimmer = accessory.addService(hap.Service.Switch, `${accessory.displayName} Dimmer`);
                 }
                 this.setupLightbulbDimmerObserver(bond, device, dimmer, d => bond.api.startDimmer(d));
               }

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,12 +111,8 @@ export class BondPlatform {
         accessory.addService(hap.Service.Switch, `${accessory.displayName} Dimmer`);
       }
       if (this.config.include_dimmer && Device.HasSeparateDimmers(device)) {
-        accessory.addService(new hap.Service.Switch(`${device.location} ${device.name} DimmerUp`, "up"));
-        accessory.addService(new hap.Service.Switch(`${device.location} ${device.name} DimmerDown`, "down"));
-      }
-      if (this.config.include_dimmer && Device.HasSeparateDimmers(device)) {
-        accessory.addService(new hap.Service.Switch(`${device.location} ${device.name} DimmerUp`, "up"));
-        accessory.addService(new hap.Service.Switch(`${device.location} ${device.name} DimmerDown`, "down"));
+        accessory.addService(new hap.Service.Switch(`${accessory.displayName} DimmerUp`, "up"));
+        accessory.addService(new hap.Service.Switch(`${accessory.displayName} DimmerDown`, "down"));
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,10 @@ export class BondPlatform {
       if (this.config.include_dimmer && Device.HasDimmer(device)) {
         accessory.addService(hap.Service.Switch, `${accessory.displayName} Dimmer`);
       }
+      if (this.config.include_dimmer && Device.HasSeparateDimmers(device)) {
+        accessory.addService(new hap.Service.Switch(`${device.location} ${device.name} DimmerUp`, "up"));
+        accessory.addService(new hap.Service.Switch(`${device.location} ${device.name} DimmerDown`, "down"));
+      }
     }
 
     if (device.type === DeviceType.Generic) {
@@ -192,16 +196,37 @@ export class BondPlatform {
             this.setupLightbulbObservers(bond, device, bulb);
 
             let dimmer = accessory.getService(`${accessory.displayName} Dimmer`);
+            let dimmerUp = accessory.getService(`${accessory.displayName} DimmerUp`);
+            let dimmerDown = accessory.getService(`${accessory.displayName} DimmerDown`);
             if (this.config.include_dimmer) {
               // Add service if previously undefined
-              if (dimmer === undefined) {
-                dimmer = accessory.addService(hap.Service.Switch, `${accessory.displayName} Dimmer`);
+              if (Device.HasDimmer(device)) {
+                if (dimmer === undefined) {
+                  this.log(`${accessory.displayName} didn't have dimmer defined. define it now`);
+                  dimmer = accessory.addService(hap.Service.Switch, `${accessory.displayName} Dimmer`);
+                }
+                this.setupLightbulbDimmerObserver(bond, device, dimmer, d => bond.api.startDimmer(d));
               }
-              this.setupLightbulbDimmerObserver(bond, device, dimmer);
+              if (Device.HasSeparateDimmers(device)) {
+                if (dimmerUp === undefined) {
+                  dimmerUp = accessory.addService(new hap.Service.Switch(`${accessory.displayName} DimmerUp`, "up"));
+                }
+                if (dimmerDown === undefined) {
+                  dimmerDown = accessory.addService(new hap.Service.Switch(`${accessory.displayName} DimmerDown`, "down"));
+                }
+                this.setupLightbulbDimmerObserver(bond, device, dimmerUp, d => bond.api.startIncreasingBrightness(d));
+                this.setupLightbulbDimmerObserver(bond, device, dimmerDown, d => bond.api.startDecreasingBrightness(d));
+              }
             } else {
               // Remove service if previously added
               if (dimmer !== undefined) {
                 accessory.removeService(dimmer);
+              }
+              if (dimmerUp !== undefined) {
+                accessory.removeService(dimmerUp);
+              }
+              if (dimmerDown !== undefined) {
+                accessory.removeService(dimmerDown);
               }
             }
           }
@@ -264,14 +289,15 @@ export class BondPlatform {
     Observer.add(this.log, bulb, hap.Characteristic.On, get, set);
   }
 
-  private setupLightbulbDimmerObserver(bond: Bond, device: Device, dimmer: HAP.Service) {
+  private setupLightbulbDimmerObserver(bond: Bond, device: Device, dimmer: HAP.Service, startCallback: (device: Device) => Promise<void>) {
     function get(): Promise<any> {
       return Promise.resolve(false);
     }
 
     function set(value: any): Promise<void> {
       if (value === true) {
-        return bond.api.startDimmer(device);
+        //return bond.api.startDimmer(device);
+        return startCallback(device);
       } else {
         return bond.api.stop(device);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -297,7 +297,6 @@ export class BondPlatform {
 
     function set(value: any): Promise<void> {
       if (value === true) {
-        //return bond.api.startDimmer(device);
         return startCallback(device);
       } else {
         return bond.api.stop(device);

--- a/src/interface/Device.ts
+++ b/src/interface/Device.ts
@@ -34,6 +34,14 @@ export namespace Device {
     return device.actions.some(r => dimmer.includes(r));
   }
 
+  export function HasSeparateDimmers(device: Device): boolean {
+    const increase = [Action.StartIncreasingBrightness];
+    const decrease = [Action.StartDecreasingBrightness];
+    const hasIncrease = device.actions.some(r => increase.includes(r));
+    const hasDecrease = device.actions.some(r => decrease.includes(r));
+    return hasIncrease && hasDecrease;
+  }
+
   export function CFhasLightbulb(device: Device): boolean {
     const lightbulb = [Action.ToggleLight];
     return device.actions.some(r => lightbulb.includes(r));


### PR DESCRIPTION
For ceiling fan lights whose remotes have 2 separate buttons for increasing brightness and decreasing brightness, this will create two separate switches in homebridge. The switches are mutually exclusive but otherwise work just like the current dimmer implementation.

PS. this is my first ever pull request, so if something is wrong or out of place, please feel free to educate me and be gentle.