### PR TITLE
Initial attempt at adding shades support

### DIFF
--- a/src/BondApi.ts
+++ b/src/BondApi.ts
@@ -106,6 +106,18 @@ export class BondApi {
     return this.request(HTTPMethod.PUT, this.uri.action(device.id, Action.TogglePower));
   }
 
+  public toggleOpen(device: Device): Promise<void> {
+    return this.request(HTTPMethod.PUT, this.uri.action(device.id, Action.ToggleOpen));
+  }
+
+  public open(device: Device): Promise<void> {
+    return this.request(HTTPMethod.PUT, this.uri.action(device.id, Action.Open));
+  }
+
+  public close(device: Device): Promise<void> {
+    return this.request(HTTPMethod.PUT, this.uri.action(device.id, Action.Close));
+  }
+
   private getDevice(id: string): Promise<Device> {
     const req = this.request(HTTPMethod.GET, this.uri.device(id));
     return req.then(json => {

--- a/src/enum/Action.ts
+++ b/src/enum/Action.ts
@@ -11,4 +11,7 @@ export enum Action {
   SetSpeed = 'SetSpeed',
   ToggleDirection = 'ToggleDirection',
   TogglePower = 'TogglePower',
+  ToggleOpen = 'ToggleOpen',
+  Open = 'Open',
+  Close = 'Close'
 }

--- a/src/interface/BondState.ts
+++ b/src/interface/BondState.ts
@@ -5,4 +5,5 @@ export interface BondState {
   up_light: number | null;
   down_light: number | null;
   direction: number | null;
+  open: number | null;
 }

--- a/src/interface/Device.ts
+++ b/src/interface/Device.ts
@@ -104,4 +104,9 @@ export namespace Device {
     const fan = [Action.TogglePower];
     return device.actions.some(r => fan.includes(r));
   }
+
+  export function MShasToggle(device: Device): boolean {
+    const fan = [Action.ToggleOpen];
+    return device.actions.some(r => fan.includes(r));
+  }
 }

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -49,5 +49,11 @@ export class BondAccessory {
         accessory.addService(this.platform.Service.Switch, accessory.displayName);
       }
     }
+
+    if (device.type === DeviceType.Shades) {
+      if (Device.MShasToggle(device)) {
+        accessory.addService(this.platform.Service.WindowCovering, accessory.displayName);
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR adds Open / Close support for shades. This does _not_ track position and takes a pretty basic / crude approach when providing information to homekit. Tracking position involves timing based on how long it takes your shades to open. https://github.com/dxdc/homebridge-blinds provides good support for this.