### PR TITLE
Update Bond API key ignore logic

### DIFF
--- a/src/BondApi.ts
+++ b/src/BondApi.ts
@@ -48,8 +48,8 @@ export class BondApi {
     const req = this.request(HTTPMethod.GET, this.uri.deviceIds());
     return req.then(json =>
       Object.keys(json).filter(x => {
-        // Ignore anything that is an empty string or all underscores
-        return x.length > 0 && !/^_+$/.test(x);
+        // Ignore anything that is an empty string or starts with underscores
+        return x.length > 0 && !/^_+/.test(x);
       }),
     );
   }
@@ -278,8 +278,8 @@ export class BondApi {
     const req = this.request(HTTPMethod.GET, this.uri.commands(id));
     return req.then(json =>
       Object.keys(json).filter(x => {
-        // Ignore anything that is an empty string or all underscores
-        return x.length > 0 && !/^_+$/.test(x);
+        // Ignore anything that is an empty string or starts with underscores
+        return x.length > 0 && !/^_+/.test(x);
       }),
     );
   }


### PR DESCRIPTION
[Per Bond developers](https://forum.bondhome.io/t/v3-3-1-beta-for-all-bridges/3328/37), ignore keys starting with underscores for devices and commands. This will help avoid breakage from future API changes.

(This is an extremely minor tweak that switches from ignoring only “all underscore” keys to “starts with underscores” keys.)