### PR TITLE
fix retry logic "Unable to find Bond for IP Address" #229

### DIFF
--- a/src/BondApi.ts
+++ b/src/BondApi.ts
@@ -322,7 +322,7 @@ export class BondApi {
         'BOND-Token': this.bondToken,
         'Bond-UUID': bondUuid,
       },
-      timeout: 1000,
+      timeout: 2000,
     });
   }
 

--- a/src/BondApi.ts
+++ b/src/BondApi.ts
@@ -42,11 +42,11 @@ export class BondApi {
           url: error.config?.url,
           method: error.config?.method,
           errorCode: error.code,
-          responseStatus: error.response?.status
+          responseStatus: error.response?.status,
         });
 
         return shouldRetry;
-      }
+      },
     });
   }
 


### PR DESCRIPTION
I had similar problems described in #229, which would resolve themselves after restarting HB.

I think it could be because, on initial startup, there are many services loading including homebridge, and a 1000 ms timeout may not have been sufficient -- especially on less powerful devices. But, when restarting it later, there was no issue.

The retry logic wasn't actually working because axiosRetry doesn't consider `ECONNABORTED` to be a retry, and shouldResetTimeout is also false by default. 

It might also be helpful to increase the length of this timeout, or make it a parameter users can set.