### PR TITLE
Fix timeout error by rate-limiting HTTP requests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@ It represents the closest reasonable ESLint configuration to this
 project's original TSLint configuration.
 
 We recommend eventually switching this configuration to extend from
-the recommended rulesets in typescript-eslint. 
+the recommended rulesets in typescript-eslint.
 https://github.com/typescript-eslint/tslint-to-eslint-config/blob/master/docs/FAQs.md
 
 Happy linting! 💖
@@ -18,7 +18,7 @@ Happy linting! 💖
     "eslint.format.enable": true,
     "files.eol": "\n",
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     "editor.rulers": [
         140

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 [![npm](https://badgen.net/npm/v/homebridge-bond)](https://www.npmjs.com/package/homebridge-bond)
 [![npm](https://badgen.net/npm/dt/homebridge-bond)](https://www.npmjs.com/package/homebridge-bond)
 
-# homebridge-bond
+# homebridge-bond-searls
+
+**This is a fork of [homebridge-bond](https://github.com/aarons22/homebridge-bond) that I made with some minor rate limit changes that were necessary to get it to work on my
+network. You probably don't want to use it.**
 
 Bond plug-in for [Homebridge](https://github.com/nfarina/homebridge) using the [Bond V2 API](http://docs-local.appbond.com).
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "axios": "^0.21.4",
     "axios-retry": "^3.1.8",
+    "axios-rate-limit": "^1.3.0",
     "biguint-format": "^1.0.2",
     "flake-idgen": "^1.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-bond-searls",
-  "version": "3.2.10",
+  "version": "3.2.11",
   "description": "An experimental fork by @searls of homebridge plugin to control your Bond devices over the v2 API.",
   "license": "MIT",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "homebridge-bond",
-  "version": "3.2.11-beta.2",
-  "description": "A homebridge plugin to control your Bond devices over the v2 API.",
+  "name": "homebridge-bond-searls",
+  "version": "3.2.10",
+  "description": "An experimental fork by @searls of homebridge plugin to control your Bond devices over the v2 API.",
   "license": "MIT",
   "main": "dist/index.js",
   "scripts": {
@@ -22,10 +22,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/aarons22/homebridge-bond.git"
+    "url": "git://github.com/searls/homebridge-bond.git"
   },
   "bugs": {
-    "url": "http://github.com/aarons22/homebridge-bond/issues"
+    "url": "http://github.com/searls/homebridge-bond/issues"
   },
   "engines": {
     "node": ">=10.17.0",
@@ -55,6 +55,6 @@
     "biguint-format": "^1.0.2",
     "flake-idgen": "^1.4.0"
   },
-  "homepage": "https://github.com/aarons22/homebridge-bond#readme",
-  "author": "Aaron Sapp"
+  "homepage": "https://github.com/searls/homebridge-bond#readme",
+  "author": "Justin Searls <searls@gmail.com>"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-bond-searls",
-  "version": "3.2.11",
+  "version": "30.2.11",
   "description": "An experimental fork by @searls of homebridge plugin to control your Bond devices over the v2 API.",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/BondApi.ts
+++ b/src/BondApi.ts
@@ -349,7 +349,7 @@ export class BondApi {
               this.platform.log.error(`A request error occurred: [status] ${response.status} [statusText] ${response.statusText}`);
           }
         } else {
-          this.platform.log.error(`A request error occurred: ${JSON.stringify(error)}`);
+          this.platform.log.error(`A request error to ${uri} occurred: ${JSON.stringify(error)}`);
         }
       });
   }

--- a/src/BondApi.ts
+++ b/src/BondApi.ts
@@ -8,6 +8,7 @@ import { Properties } from './interface/Properties';
 import { Version } from './interface/Version';
 import axios, { AxiosError } from 'axios';
 import axiosRetry from 'axios-retry';
+import axiosRateLimit, { RateLimitedAxiosInstance } from 'axios-rate-limit';
 import FlakeId from 'flake-idgen';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const intformat = require('biguint-format');
@@ -23,6 +24,7 @@ const flakeIdGen = new FlakeId();
 export class BondApi {
   private bondToken: string;
   private uri: BondUri;
+  private http: RateLimitedAxiosInstance;
 
   constructor(
     private readonly platform: BondPlatform,
@@ -30,24 +32,9 @@ export class BondApi {
     ipAddress: string) {
     this.bondToken = bondToken;
     this.uri = new BondUri(ipAddress);
+    this.http = axiosRateLimit(axios.create(), { maxRequests: 2, perMilliseconds: 1000 });
 
-    axiosRetry(axios, {
-      retries: 10,
-      retryDelay: axiosRetry.exponentialDelay,
-      shouldResetTimeout: true,
-      retryCondition: (error) => {
-        const shouldRetry = axiosRetry.isNetworkOrIdempotentRequestError(error) || error.code === 'ECONNABORTED';
-
-        this.platform.log.debug(`Retrying: ${shouldRetry ? 'YES' : 'NO'}`, {
-          url: error.config?.url,
-          method: error.config?.method,
-          errorCode: error.code,
-          responseStatus: error.response?.status,
-        });
-
-        return shouldRetry;
-      },
-    });
+    axiosRetry(this.http, { retries: 10, retryDelay: axiosRetry.exponentialDelay });
   }
 
   // Bond / Device Info
@@ -315,7 +302,7 @@ export class BondApi {
   ping(): Promise<any> {
     const uuid = intformat(flakeIdGen.next(), 'hex', { prefix: '18', padstr: '0', size: 16 }); // avoid duplicate action
     const bondUuid = uuid.substring(0, 13) + uuid.substring(15); // remove '00' used for datacenter/worker in flakeIdGen
-    return axios({
+    return this.http({
       method: HTTPMethod.GET,
       url: this.uri.deviceIds(),
       headers: {
@@ -337,7 +324,7 @@ export class BondApi {
       this.platform.log.debug(`Request (${bondUuid}) [${method} ${uri}]`);
     }
 
-    return axios({
+    return this.http({
       method,
       url: uri,
       headers: {


### PR DESCRIPTION
Introduce the `axios-rate-limit` package to slow down initial requests long enough that the Bond Pro bridge does not become overwhelmed. Tested that this works fine locally and on my homebridge server.

Unsure what the right simultaneous request limit and time limit is, but this was enough to avoid 10 second timeouts and get the devices to once again be responsive in the Home app.

Fixes #201