### PR TITLE
add support for Position feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-bond",
-  "version": "3.2.11",
+  "version": "3.2.12",
   "description": "A homebridge plugin to control your Bond devices over the v2 API.",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/BondApi.ts
+++ b/src/BondApi.ts
@@ -218,6 +218,20 @@ export class BondApi {
       });
   }
 
+  public setPosition(device: Device, position: number, callback?: CharacteristicSetCallback): Promise<void> {
+    return this.request(HTTPMethod.PUT, this.uri.action(device.id, Action.SetPosition), { argument: position })
+      .then(() => {
+        if (callback) {
+          callback(null);
+        }
+      })
+      .catch((error: string) => {
+        if (callback) {
+          callback(Error(error));
+        }
+      });
+  }
+
   public setFanSpeed(device: Device, speed: CharacteristicValue, callback: CharacteristicSetCallback): Promise<void> {
     return this.action(device, Action.SetSpeed, callback, { argument: speed as number });
   }

--- a/src/enum/Action.ts
+++ b/src/enum/Action.ts
@@ -21,5 +21,6 @@ export enum Action {
   Open = 'Open',
   Close = 'Close',
   Preset = 'Preset',
-  SetFlame = 'SetFlame'
+  SetFlame = 'SetFlame',
+  SetPosition = 'SetPosition'
 }

--- a/src/interface/Bond.ts
+++ b/src/interface/Bond.ts
@@ -137,6 +137,7 @@ export interface BondState {
   open?: number;
   brightness?: number;
   flame?: number;
+  position?: number;
 }
 
 export interface BPUPPacket {

--- a/src/interface/Device.ts
+++ b/src/interface/Device.ts
@@ -139,4 +139,9 @@ export namespace Device {
       return vals.sort();
     }
   }
+
+  export function MShasPosition(device: Device): boolean {
+    const required = [Action.SetPosition];
+    return required.every(r => device.actions.includes(r));
+  }
 }


### PR DESCRIPTION
If the shade has SetPosition action on the API, then Home app will support position setting. If Position not supported, the old ToggleOpen behavior will be used.