### PR TITLE
Homebridge 2 verified: update deprecated APIs and CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,15 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }} 
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: npm install, lint, build and test

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '14.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       
       - name: Configure Git

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "engines": {
     "node": "^18.20.4 || ^20.15.1 || ^22 || ^24",
-    "homebridge": "^1.6.0 || ^2.0.0-beta.0"
+    "homebridge": "^1.8.0 || ^2.0.0-beta.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.14",

--- a/src/Services.ts
+++ b/src/Services.ts
@@ -173,12 +173,11 @@ export class ButtonService {
     }
 
     this.on = service.getCharacteristic(platform.Characteristic.On);
-    this.on.setValue(false);
+    this.on.updateValue(false);
 
-    this.on.on('set', () => {
-      const timer = setInterval(() => {
+    this.on.onSet(async () => {
+      setTimeout(() => {
         this.on.updateValue(false);
-        clearInterval(timer);
       }, 500);
     });
     this.subType = subType;


### PR DESCRIPTION
## Summary
- Convert `ButtonService` from deprecated `.on('set')` event pattern to `.onSet()` (required for Homebridge 2 / HAP-NodeJS v2)
- Use `updateValue()` instead of `setValue()` for initial characteristic state to avoid triggering set handlers during init
- Bump `engines.homebridge` minimum from `^1.6.0` to `^1.8.0` to match the current Homebridge plugin template
- Add Node 24.x to CI test matrix (already declared in `engines.node`)
- Update GitHub Actions (`actions/checkout` v2→v4, `actions/setup-node` v1→v4)
- Fix version-bump workflow Node version from 14.x to 20.x

## Context
The plugin already had most Homebridge 2 compatibility in place. The remaining issues were:
1. `ButtonService` used the deprecated `.on('set', callback)` EventEmitter pattern which is removed in HAP-NodeJS v2 (shipped with Homebridge 2). Migrated to `.onSet()`.
2. CI wasn't testing against Node 24 despite `engines.node` supporting it.
3. GitHub Actions were using outdated versions (v1/v2 instead of v4).
4. The version-bump workflow was using Node 14.x which doesn't even meet the plugin's own engine requirements.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` compiles successfully
- [x] `npm test` — all 46 tests pass
- [x] CI passes on Node 18.x, 20.x, 22.x, and 24.x
- [x] Test ButtonService behavior (button resets to off after 500ms tap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)