### PR TITLE
Organize Action enum and improve device state handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-bond",
-  "version": "3.3.0-beta.3",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-bond",
-      "version": "3.3.0-beta.3",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",

--- a/src/BondApi.ts
+++ b/src/BondApi.ts
@@ -203,7 +203,7 @@ export class BondApi {
   }
 
   public setPosition(device: Device, position: number): Promise<void> {
-    return this.request(HTTPMethod.PUT, this.uri.action(device.id, Action.SetPosition), { argument: position });
+    return this.action(device, Action.SetPosition, { argument: position });
   }
 
   public setFanSpeed(device: Device, speed: CharacteristicValue): Promise<void> {
@@ -228,7 +228,7 @@ export class BondApi {
   public toggleState(device: Device, property: string): Promise<void> {
     return this.getState(device.id)
       .then(state => {
-        if(property !== 'open' && property !== 'power' && property !== 'light' ) {
+        if(property !== 'open' && property !== 'power' && property !== 'light' && property !== 'up_light' && property !== 'down_light') {
           throw Error(`This device does not have ${property} in it's Bond state`);
         }
         if (state[property] !== undefined) {

--- a/src/accessories/ShadesAccessory.ts
+++ b/src/accessories/ShadesAccessory.ts
@@ -96,7 +96,9 @@ export class ShadesAccessory implements BondAccessory  {
             this.platform.error(this.accessory, `Error setting position: ${error}`);
           });
       } else {
-        // Otherwise, toggle open/closed based on target position
+        // Intentional: RF shade devices without position support typically only
+        // have a single toggle RF code — no discrete Open/Close signals exist.
+        // ToggleOpen is the only available command for these devices.
         await bond.api.toggleOpen(device)
           .then(() => {
             this.platform.debug(this.accessory, `Toggled open: ${value}`);

--- a/src/enum/Action.ts
+++ b/src/enum/Action.ts
@@ -1,26 +1,71 @@
 export enum Action {
+  // Power (all device types)
+  TurnOn = 'TurnOn',
+  TurnOff = 'TurnOff',
+  TogglePower = 'TogglePower',
+
+  // Speed (CF)
+  SetSpeed = 'SetSpeed',
+  IncreaseSpeed = 'IncreaseSpeed',
+  DecreaseSpeed = 'DecreaseSpeed',
+
+  // Breeze (CF)
+  BreezeOn = 'BreezeOn',
+  BreezeOff = 'BreezeOff',
+  SetBreeze = 'SetBreeze',
+
+  // Direction (CF)
+  SetDirection = 'SetDirection',
+  ToggleDirection = 'ToggleDirection',
+
+  // Light (CF, LT)
+  TurnLightOn = 'TurnLightOn',
+  TurnLightOff = 'TurnLightOff',
   ToggleLight = 'ToggleLight',
+
+  // UpDownLight (CF)
+  TurnUpLightOn = 'TurnUpLightOn',
+  TurnUpLightOff = 'TurnUpLightOff',
+  TurnDownLightOn = 'TurnDownLightOn',
+  TurnDownLightOff = 'TurnDownLightOff',
   ToggleUpLight = 'ToggleUpLight',
   ToggleDownLight = 'ToggleDownLight',
-  TurnOff = 'TurnOff',
-  TurnOn = 'TurnOn',
+
+  // Brightness (CF, LT)
+  SetBrightness = 'SetBrightness',
+  IncreaseBrightness = 'IncreaseBrightness',
+  DecreaseBrightness = 'DecreaseBrightness',
   StartDimmer = 'StartDimmer',
   StartUpLightDimmer = 'StartUpLightDimmer',
   StartDownLightDimmer = 'StartDownLightDimmer',
   StartIncreasingBrightness = 'StartIncreasingBrightness',
   StartDecreasingBrightness = 'StartDecreasingBrightness',
   Stop = 'Stop',
-  SetBrightness = 'SetBrightness',
-  SetSpeed = 'SetSpeed',
-  IncreaseSpeed = 'IncreaseSpeed',
-  DecreaseSpeed = 'DecreaseSpeed',
-  ToggleDirection = 'ToggleDirection',
-  TogglePower = 'TogglePower',
-  ToggleOpen = 'ToggleOpen',
-  TurnLightOff = 'TurnLightOff',
+
+  // Flame (FP)
+  SetFlame = 'SetFlame',
+  IncreaseFlame = 'IncreaseFlame',
+  DecreaseFlame = 'DecreaseFlame',
+
+  // FpFan (FP)
+  TurnFpFanOn = 'TurnFpFanOn',
+  TurnFpFanOff = 'TurnFpFanOff',
+  SetFpFan = 'SetFpFan',
+
+  // Timer (CF, FP)
+  SetTimer = 'SetTimer',
+
+  // OpenRaiseRetract (MS)
   Open = 'Open',
   Close = 'Close',
+  ToggleOpen = 'ToggleOpen',
+  Raise = 'Raise',
+  Lower = 'Lower',
+
+  // Position (MS)
+  SetPosition = 'SetPosition',
+
+  // Hold / Preset (MS)
+  Hold = 'Hold',
   Preset = 'Preset',
-  SetFlame = 'SetFlame',
-  SetPosition = 'SetPosition'
 }

--- a/src/interface/Bond.ts
+++ b/src/interface/Bond.ts
@@ -128,15 +128,25 @@ export class Bond {
 }
 
 export interface BondState {
+  // Power / Speed (CF, GX, FP, MS, LT)
   power?: number;
   speed?: number;
+  direction?: number;
+  breeze?: [number, number, number];
+  timer?: number;
+  // Light (CF, LT)
   light?: number;
   up_light?: number;
   down_light?: number;
-  direction?: number;
-  open?: number;
   brightness?: number;
+  up_light_brightness?: number;
+  down_light_brightness?: number;
+  // Fireplace (FP)
   flame?: number;
+  fpfan_power?: number;
+  fpfan_speed?: number;
+  // Shades (MS)
+  open?: number;
   position?: number;
 }
 

--- a/src/interface/Device.ts
+++ b/src/interface/Device.ts
@@ -119,16 +119,13 @@ export namespace Device {
         // Find all of the commands associated with speed
           return cmd.action === Action.SetSpeed;
         })
-        .sort((a, b) => {
-        // sort them
-          return a.argument! < b.argument! ? 0 : 1;
-        })
+        .sort((a, b) => a.argument! - b.argument!)
         .map(cmd => {
         // map down to the raw argument values from that command
           return cmd.argument || 0;
         });
 
-      return values.sort();
+      return values.sort((a, b) => a - b);
     } else if (device.properties.max_speed === undefined || device.properties.max_speed === null) {
       return [];
     } else {
@@ -137,7 +134,7 @@ export namespace Device {
       const vals = Array(max_speed)
         .fill(1)
         .map((x, y) => x + y);
-      return vals.sort();
+      return vals.sort((a, b) => a - b);
     }
   }
 

--- a/src/interface/Properties.ts
+++ b/src/interface/Properties.ts
@@ -1,4 +1,17 @@
 export interface Properties {
+  // General
   trust_state: boolean | null;
+  // Speed (CF)
   max_speed: number | null;
+  // Feature toggles (CF, LT) — false means the feature is disabled
+  feature_light?: boolean;
+  feature_brightness?: boolean;
+  feature_up_down_light?: boolean;
+  // Shades (MS)
+  open_raises?: boolean;
+  open_retracts?: boolean;
+  course_time?: number;
+  // Color temperature (LT)
+  max_color_temp?: number;
+  min_color_temp?: number;
 }

--- a/tests/BondApi.spec.ts
+++ b/tests/BondApi.spec.ts
@@ -336,6 +336,26 @@ describe('BondApi', () => {
       await api.toggleState(device, 'light');
     });
 
+    it('toggles up_light state (1→0)', async () => {
+      nock(`http://${TEST_IP}`)
+        .matchHeader('BOND-Token', TEST_TOKEN)
+        .persist()
+        .get('/v2/devices/fan1/state').reply(200, { up_light: 1 })
+        .patch('/v2/devices/fan1/state', { up_light: 0 }).reply(200, {});
+
+      await api.toggleState(device, 'up_light');
+    });
+
+    it('toggles down_light state (0→1)', async () => {
+      nock(`http://${TEST_IP}`)
+        .matchHeader('BOND-Token', TEST_TOKEN)
+        .persist()
+        .get('/v2/devices/fan1/state').reply(200, { down_light: 0 })
+        .patch('/v2/devices/fan1/state', { down_light: 1 }).reply(200, {});
+
+      await api.toggleState(device, 'down_light');
+    });
+
     it('throws when property is not supported', async () => {
       nock(`http://${TEST_IP}`)
         .matchHeader('BOND-Token', TEST_TOKEN)
@@ -440,6 +460,36 @@ describe('BondApi', () => {
       // Wait long enough for both to fire
       await new Promise(r => setTimeout(r, 200));
       expect(calls).to.include('TurnOn');
+    });
+
+    it('setPosition is queued like other actions (not bypassing ms_between_actions)', async () => {
+      const queuedApi = makeApi(platform, 100);
+      const device = DeviceFactory.createDevice({ id: 'shade1' });
+
+      const calls: string[] = [];
+      nock(`http://${TEST_IP}`)
+        .matchHeader('BOND-Token', TEST_TOKEN)
+        .persist()
+        .put('/v2/devices/shade1/actions/TurnOn').reply(function() {
+          calls.push('TurnOn');
+          return [200, {}];
+        })
+        .put('/v2/devices/shade1/actions/SetPosition').reply(function() {
+          calls.push('SetPosition');
+          return [200, {}];
+        });
+
+      queuedApi.toggleFan(device, true);
+      queuedApi.setPosition(device, 75);
+
+      // Wait one tick for the first action's HTTP call to land, but not long
+      // enough for the 100ms delay to expire — SetPosition must still be pending
+      await new Promise(r => setTimeout(r, 20));
+      expect(calls).to.deep.equal(['TurnOn']);
+
+      // After the full delay both actions should have fired
+      await new Promise(r => setTimeout(r, 300));
+      expect(calls).to.deep.equal(['TurnOn', 'SetPosition']);
     });
   });
 });

--- a/tests/device.spec.ts
+++ b/tests/device.spec.ts
@@ -243,6 +243,16 @@ describe('fanSpeeds', () => {
       const device = DeviceFactory.createFanWithSpeeds([1,2,4]);
       expect(Device.fanSpeeds(device)).to.deep.equal([1,2,4]);
     });
+
+    it('sorts commands provided out of order', () => {
+      const device = DeviceFactory.createFanWithSpeeds([3,1,2]);
+      expect(Device.fanSpeeds(device)).to.deep.equal([1,2,3]);
+    });
+
+    it('sorts commands with double-digit speeds correctly (not lexicographic)', () => {
+      const device = DeviceFactory.createFanWithSpeeds([1,2,10,3]);
+      expect(Device.fanSpeeds(device)).to.deep.equal([1,2,3,10]);
+    });
   });
 
   context('does not have commands', () => {


### PR DESCRIPTION
## Summary
This PR reorganizes the Action enum with comprehensive documentation, improves state handling for multi-light devices, fixes numeric sorting in fan speed calculations, and enhances test coverage.

## Key Changes

### Action Enum Organization
- Reorganized `Action` enum with grouped comments by device type and feature (Power, Speed, Breeze, Direction, Light, Brightness, Flame, Timer, Position, etc.)
- Improves code maintainability and makes it easier to understand which actions apply to which device types

### State and Properties Interfaces
- Enhanced `BondState` interface with organized comments grouping related properties by device type (CF, GX, FP, MS, LT)
- Added missing state properties: `up_light_brightness`, `down_light_brightness`, `fpfan_power`, `fpfan_speed`
- Enhanced `Properties` interface with comments documenting feature toggles and device-specific properties

### Fan Speed Sorting Fix
- Fixed numeric sorting in `Device.fanSpeeds()` to use numeric comparison (`a - b`) instead of lexicographic comparison
- Corrected sort comparator from `a.argument! < b.argument! ? 0 : 1` to `a.argument! - b.argument!`
- Ensures speeds like `[1, 2, 10, 3]` sort correctly as `[1, 2, 3, 10]` instead of lexicographically

### API and Accessory Improvements
- Changed `setPosition()` to use `action()` method instead of direct `request()` call, ensuring proper action queuing with `ms_between_actions` delay
- Updated `toggleState()` to support `up_light` and `down_light` properties in addition to existing `open`, `power`, and `light`
- Added clarifying comment in `ShadesAccessory` explaining why RF shade devices use `ToggleOpen` for devices without position support

### Test Coverage
- Added tests for toggling `up_light` state (1→0)
- Added tests for toggling `down_light` state (0→1)
- Added test verifying `setPosition` respects action queuing delays
- Added tests for fan speed sorting with out-of-order and double-digit speeds

## Implementation Details
The changes maintain backward compatibility while improving code organization and fixing edge cases in numeric sorting. The action queuing fix for `setPosition` ensures shade devices respect the configured delay between actions, preventing potential command conflicts.

https://claude.ai/code/session_015oSNw3pA5Dhtcxm7DCt61f