### PR TITLE
[codex] Fix Homebridge control paths found by simulator

### DIFF
--- a/src/Observer.ts
+++ b/src/Observer.ts
@@ -3,7 +3,8 @@ import { Characteristic, CharacteristicValue } from 'homebridge';
 export class Observer {
   public static set(
     characteristic: Characteristic,
-    set: (value: CharacteristicValue) => Promise<void>) {
+    set: (value: CharacteristicValue) => Promise<void>,
+    options: { resetToFalse?: boolean } = {}) {
     characteristic 
       .onSet(async (value: CharacteristicValue) => {
         // Avoid doing anything when the device is in the requested state
@@ -11,7 +12,17 @@ export class Observer {
           return;
         }
 
+        if (options.resetToFalse && value !== true) {
+          return;
+        }
+
         await set(value);
+
+        if (options.resetToFalse) {
+          setTimeout(() => {
+            characteristic.updateValue(false);
+          }, 500);
+        }
       });
   }
 }

--- a/src/Services.ts
+++ b/src/Services.ts
@@ -174,13 +174,6 @@ export class ButtonService {
 
     this.on = service.getCharacteristic(platform.Characteristic.On);
     this.on.setValue(false);
-
-    this.on.on('set', () => {
-      const timer = setInterval(() => {
-        this.on.updateValue(false);
-        clearInterval(timer);
-      }, 500);
-    });
     this.subType = subType;
   }
 }
@@ -243,7 +236,10 @@ export class FlameService {
   }
 
   updateState(state: BondState) {
-    if (this.flame && state.flame) {
+    if (state.power !== undefined) {
+      this.on.updateValue(state.power === 1);
+    }
+    if (this.flame && state.flame !== undefined) {
       this.flame.updateValue(state.flame);
     }
   }

--- a/src/accessories/CeilingFanAccessory.ts
+++ b/src/accessories/CeilingFanAccessory.ts
@@ -268,7 +268,7 @@ export class CeilingFanAccessory implements BondAccessory  {
         .catch((error: string) => {
           this.platform.error(this.accessory, `Error increasing fan speed: ${error}`);
         });
-    });
+    }, { resetToFalse: true });
   }
 
   private observeFanDecreaseSpeed(bond: Bond, device: Device) {
@@ -284,7 +284,7 @@ export class CeilingFanAccessory implements BondAccessory  {
         .catch((error: string) => {
           this.platform.error(this.accessory, `Error decreasing fan speed: ${error}`);
         });
-    });
+    }, { resetToFalse: true });
   }
 
   private observeLightToggle(bond: Bond, device: Device, service?: ButtonService) {
@@ -296,9 +296,9 @@ export class CeilingFanAccessory implements BondAccessory  {
       let promise: Promise<void>;
 
       const subtype = service.subType;
-      if(subtype === 'UpLight') {
+      if(subtype === 'UpLight' || subtype === 'ToggleUpLight') {
         promise = bond.api.toggleState(device, 'up_light');
-      } else if(subtype === 'DownLight') {
+      } else if(subtype === 'DownLight' || subtype === 'ToggleDownLight') {
         promise = bond.api.toggleState(device, 'down_light');
       } else {
         promise = bond.api.toggleState(device, 'light');
@@ -311,7 +311,7 @@ export class CeilingFanAccessory implements BondAccessory  {
         .catch((error: string) => {
           this.platform.error(this.accessory, `Error toggling light state: ${error}`);
         });
-    });
+    }, { resetToFalse: true });
   }
 
   private observeLightDimmer(bond: Bond, device: Device, service?: SwitchService) {

--- a/src/accessories/FireplaceAccessory.ts
+++ b/src/accessories/FireplaceAccessory.ts
@@ -61,7 +61,7 @@ export class FireplaceAccessory implements BondAccessory {
         .catch((error: string) => {
           this.platform.error(this.accessory, `Error toggling power state: ${error}`);
         });
-    });
+    }, { resetToFalse: true });
   }
 
   private removeService(serviceName: string) {

--- a/src/accessories/GenericAccessory.ts
+++ b/src/accessories/GenericAccessory.ts
@@ -70,7 +70,7 @@ export class GenericAccessory implements BondAccessory  {
         .catch((error: string) => {
           this.platform.error(this.accessory, `Error toggling power state: ${error}`);
         });
-    });
+    }, { resetToFalse: true });
   }
 
   private removeService(serviceName: string) {

--- a/src/accessories/LightAccessory.ts
+++ b/src/accessories/LightAccessory.ts
@@ -57,7 +57,7 @@ export class LightAccessory implements BondAccessory {
         .catch((error: string) => {
           this.platform.error(this.accessory, `Error toggling light state: ${error}`);
         });
-    });
+    }, { resetToFalse: true });
   }
 
   private removeService(serviceName: string) {

--- a/src/accessories/ShadesAccessory.ts
+++ b/src/accessories/ShadesAccessory.ts
@@ -123,7 +123,7 @@ export class ShadesAccessory implements BondAccessory  {
         .catch((error: string) => {
           this.platform.error(this.accessory, `Error executing preset: ${error}`);
         });
-    });
+    }, { resetToFalse: true });
   }
 
   private observeToggleState(bond: Bond, device: Device) {
@@ -139,7 +139,7 @@ export class ShadesAccessory implements BondAccessory  {
         .catch((error: string) => {
           this.platform.error(this.accessory, `Error toggling open state: ${error}`);
         });
-    });
+    }, { resetToFalse: true });
   }
 
   private removeService(serviceName: string) {

--- a/tests/accessories/CeilingFanAccessory.spec.ts
+++ b/tests/accessories/CeilingFanAccessory.spec.ts
@@ -346,6 +346,42 @@ describe('CeilingFanAccessory', () => {
       sinon.assert.calledWith(bond.api.toggleState as sinon.SinonStub, device, 'light');
     });
 
+    it('calls toggleState for up_light when toggle up light button pressed', async () => {
+      const { accessory, bond, device } = buildFan(
+        FAN_ACTIONS_WITH_UPDOWN, 3, { include_toggle_state: true },
+      );
+      const toggleSvc = accessory.getServiceById(ServiceTokens.Switch, 'ToggleUpLight');
+      const on = toggleSvc!.getCharacteristic(CharacteristicTokens.On) as MockCharacteristic;
+      on.value = false;
+      await on.simulateSet(true);
+      sinon.assert.calledWith(bond.api.toggleState as sinon.SinonStub, device, 'up_light');
+    });
+
+    it('calls toggleState for down_light when toggle down light button pressed', async () => {
+      const { accessory, bond, device } = buildFan(
+        FAN_ACTIONS_WITH_UPDOWN, 3, { include_toggle_state: true },
+      );
+      const toggleSvc = accessory.getServiceById(ServiceTokens.Switch, 'ToggleDownLight');
+      const on = toggleSvc!.getCharacteristic(CharacteristicTokens.On) as MockCharacteristic;
+      on.value = false;
+      await on.simulateSet(true);
+      sinon.assert.calledWith(bond.api.toggleState as sinon.SinonStub, device, 'down_light');
+    });
+
+    it('resets button services after a press', async () => {
+      const clock = sinon.useFakeTimers();
+      const { accessory, bond } = buildFan(FAN_ACTIONS_INC_DEC);
+      const svc = accessory.getServiceById(ServiceTokens.Switch, 'IncreaseSpeed');
+      const on = svc!.getCharacteristic(CharacteristicTokens.On) as MockCharacteristic;
+      on.value = false;
+
+      await on.simulateSet(true);
+      await clock.tickAsync(500);
+
+      expect(on.value).to.equal(false);
+      sinon.assert.calledOnce(bond.api.increaseSpeed as sinon.SinonStub);
+    });
+
     it('calls startDimmer when dimmer turned on', async () => {
       const { accessory, bond, device } = buildFan(
         [...FAN_ACTIONS_WITH_LIGHT, Action.StartDimmer], 3, { include_dimmer: true },

--- a/tests/accessories/FireplaceAccessory.spec.ts
+++ b/tests/accessories/FireplaceAccessory.spec.ts
@@ -74,17 +74,39 @@ describe('FireplaceAccessory', () => {
 
   // -------------------------------------------------------------------------
   // updateState
-  // FlameService.updateState only updates the flame brightness characteristic;
-  // the power (on) characteristic is driven by observer callbacks, not state updates.
   // -------------------------------------------------------------------------
 
   describe('updateState()', () => {
+    it('updates switch power when power value present', () => {
+      const { acc, accessory } = buildFireplace([Action.TogglePower]);
+      acc.updateState({ power: 1 });
+      const svc = accessory.getServiceById(ServiceTokens.Switch, 'Flame');
+      const on = svc!.getCharacteristic(CharacteristicTokens.On) as MockCharacteristic;
+      expect(on.value).to.equal(true);
+    });
+
+    it('updates lightbulb power when power value present', () => {
+      const { acc, accessory } = buildFireplace([Action.TogglePower, Action.SetFlame]);
+      acc.updateState({ power: 0 });
+      const svc = accessory.getServiceById(ServiceTokens.Lightbulb, 'Flame');
+      const on = svc!.getCharacteristic(CharacteristicTokens.On) as MockCharacteristic;
+      expect(on.value).to.equal(false);
+    });
+
     it('updates flame brightness when flame value present', () => {
       const { acc, accessory } = buildFireplace([Action.TogglePower, Action.SetFlame]);
       acc.updateState({ power: 1, flame: 60 });
       const svc = accessory.getServiceById(ServiceTokens.Lightbulb, 'Flame');
       const brightness = svc!.getCharacteristic(CharacteristicTokens.Brightness) as MockCharacteristic;
       expect(brightness.value).to.equal(60);
+    });
+
+    it('updates flame brightness when flame value is 0', () => {
+      const { acc, accessory } = buildFireplace([Action.TogglePower, Action.SetFlame]);
+      acc.updateState({ flame: 0 });
+      const svc = accessory.getServiceById(ServiceTokens.Lightbulb, 'Flame');
+      const brightness = svc!.getCharacteristic(CharacteristicTokens.Brightness) as MockCharacteristic;
+      expect(brightness.value).to.equal(0);
     });
 
     it('updates flame brightness to a different value', () => {


### PR DESCRIPTION
## Summary

This PR contains only the plugin/library fixes discovered while testing the Bond simulator through the Homebridge UI API. It now branches from and targets `main`, so it can be reviewed independently from the simulator work.

## Rationale

With `include_dimmer` and `include_toggle_state` enabled, the simulator exposed three plugin-side issues:

- Momentary button services used both Homebridge `onSet` and legacy `on('set')` handlers. Homebridge v2 warned about this and some button controls could remain pressed or get ignored on a later write.
- Up/down fan light toggle-state buttons used subtypes `ToggleUpLight` and `ToggleDownLight`, but the observer only mapped `UpLight` and `DownLight`, so those buttons patched the generic `light` state instead of `up_light` / `down_light`.
- Fireplace BPUP `power` updates were received but did not update the HomeKit `On` characteristic, leaving Homebridge's cached state stale and allowing a later command to be de-duplicated before reaching Bond. The same update path also ignored `flame: 0`.

## Changes

- Adds an optional `resetToFalse` mode to `Observer.set` for momentary button services.
- Moves button reset behavior out of the legacy `on('set')` handler and into the shared `onSet` flow.
- Applies the reset behavior to light, fan, shade, fireplace, and generic toggle/preset/speed button services.
- Maps fan toggle-button subtypes to `up_light` and `down_light` correctly.
- Syncs fireplace `power` state into HomeKit `On`, and accepts `flame: 0` as a valid brightness update.
- Adds focused tests for the fixed button, fan light, and fireplace state behavior.

## Validation

- `npm run lint` passed.
- `npm run build` passed.
- `npm test` passed: `237 passing` on the main-based branch.
- Earlier live Homebridge UI API matrix against the simulator passed: `38/38`.
- Homebridge logs during that matrix run had no warnings/errors.