### PR TITLE
[codex] Add Bond simulator test harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ npm run lint       # ESLint TypeScript files
 1. `npm link` in plugin directory to symlink globally
 2. Homebridge will use local build from `dist/`
 3. Check logs at `~/.homebridge/` (platform logs via Homebridge API)
+4. Do not start or restart the user's existing simulator on port 30007. If UI or API verification needs a simulator, start a temporary HTTP-only simulator on a separate port and stop it when finished.
 
 ### Common Issues
 - **Accessories not updating**: Check BPUP socket setup - UDP port 30007 must be open

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "main": "dist/index.js",
   "scripts": {
-    "lint": "eslint src/**.ts",
+    "lint": "eslint src/**.ts tools/bond-simulator/*.ts",
+    "simulator": "ts-node tools/bond-simulator/cli.ts",
     "watch": "npm run build && npm link && nodemon",
     "dev": "tsc --watch & nodemon dist",
     "build": "rimraf ./dist && tsc -p tsconfig-build.json",

--- a/src/accessories/LightAccessory.ts
+++ b/src/accessories/LightAccessory.ts
@@ -18,7 +18,7 @@ export class LightAccessory implements BondAccessory {
     bond: Bond) {
     this.platform = platform;
     this.accessory = accessory;
-    this.lightService = new LightbulbService(platform, accessory, `${accessory.displayName} Light`);
+    this.lightService = new LightbulbService(platform, accessory, accessory.displayName);
     if (platform.config.include_toggle_state) {
       this.toggleLightService = new ButtonService(platform, accessory, 'Toggle Light State', 'ToggleState');
     } else {

--- a/src/interface/Device.ts
+++ b/src/interface/Device.ts
@@ -27,7 +27,7 @@ export interface Command {
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Device {
   export function displayName(device: Device): string {
-    return `${device.location} ${device.name}`;
+    return device.location ? `${device.location} ${device.name}` : device.name;
   }
 
   export function isSupported(device: Device): boolean {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -245,7 +245,7 @@ export class BondPlatform implements DynamicPlatformPlugin {
 
   private setupBPUP(bond: Bond) {
     const PORT = 30007;
-    const HOST = bond.config.ip_address;
+    const HOST = this.bpupHost(bond.config.ip_address);
 
     const message = Buffer.from('');
 
@@ -256,8 +256,8 @@ export class BondPlatform implements DynamicPlatformPlugin {
     function send() {
       client.send(message, 0, message.length, PORT, HOST, (err: any) => {
         if (err) {
-          log.error(`Erorr sending UDP message: ${err}`);
-          throw err;
+          log.error(`Error sending UDP message: ${err}`);
+          return;
         }
         log.debug(`UDP message sent to ${HOST}:${PORT}`);
       });
@@ -281,6 +281,10 @@ export class BondPlatform implements DynamicPlatformPlugin {
     client.on('close', () => {
       this.log('Connection closed');
     });
+  }
+
+  private bpupHost(ipAddress: string): string {
+    return new URL(`http://${ipAddress}`).hostname;
   }
 
   private bondForDevice(device: Device): Bond | undefined {

--- a/tests/bondSimulator.spec.ts
+++ b/tests/bondSimulator.spec.ts
@@ -14,6 +14,7 @@ import {
   SIM_DIMMABLE_LIGHT_ID,
   SIM_DIRECTION_FAN_ID,
   SIM_FLAME_FIREPLACE_ID,
+  SIM_GENERIC_ID,
   SIM_LIGHT_ID,
   SIM_LIGHT_FAN_ID,
   SIM_AWNING_SHADE_ID,
@@ -211,6 +212,19 @@ describe('Bond simulator', () => {
       type: 'FP',
     });
     expect(flameFireplace.body.actions).to.deep.equal(['TogglePower', 'SetFlame']);
+  });
+
+  it('returns the generic device catalog with expected capability shapes', async () => {
+    const list = await request(port, 'GET', '/v2/devices', undefined, DEFAULT_TOKEN);
+    const generic = await request(port, 'GET', `/v2/devices/${SIM_GENERIC_ID}`, undefined, DEFAULT_TOKEN);
+
+    expect(list.body).to.include.keys(SIM_GENERIC_ID);
+    expect(generic.body).to.deep.include({
+      name: 'Generic Toggle',
+      location: DEFAULT_DEVICE_LOCATION,
+      type: 'GX',
+    });
+    expect(generic.body.actions).to.deep.equal(['TogglePower']);
   });
 
   it('rejects protected endpoints without the simulator token', async () => {
@@ -447,6 +461,53 @@ describe('Bond simulator', () => {
     expect(state.body).to.deep.equal({ power: 1, speed: 1 });
   });
 
+  it('accepts brightness button fan hold actions without exposing discrete brightness state', async () => {
+    const increase = await request(
+      port,
+      'PUT',
+      `/v2/devices/${SIM_BRIGHTNESS_BUTTON_FAN_ID}/actions/StartIncreasingBrightness`,
+      {},
+      DEFAULT_TOKEN,
+    );
+    const activeState = await request(port, 'GET', `/v2/devices/${SIM_BRIGHTNESS_BUTTON_FAN_ID}/state`, undefined, DEFAULT_TOKEN);
+    const stop = await request(port, 'PUT', `/v2/devices/${SIM_BRIGHTNESS_BUTTON_FAN_ID}/actions/Stop`, {}, DEFAULT_TOKEN);
+    const state = await request(port, 'GET', `/v2/devices/${SIM_BRIGHTNESS_BUTTON_FAN_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(increase.statusCode).to.equal(200);
+    expect(activeState.body).to.deep.equal({
+      power: 0,
+      speed: 1,
+      light: 0,
+      active_hold: 'StartIncreasingBrightness',
+    });
+    expect(stop.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({
+      power: 0,
+      speed: 1,
+      light: 0,
+    });
+  });
+
+  it('tracks up and down light dimmer hold actions until Stop', async () => {
+    const start = await request(
+      port,
+      'PUT',
+      `/v2/devices/${SIM_UP_DOWN_DIMMER_FAN_ID}/actions/StartUpLightDimmer`,
+      {},
+      DEFAULT_TOKEN,
+    );
+    const activeState = await request(port, 'GET', `/v2/devices/${SIM_UP_DOWN_DIMMER_FAN_ID}/state`, undefined, DEFAULT_TOKEN);
+    const stop = await request(port, 'PUT', `/v2/devices/${SIM_UP_DOWN_DIMMER_FAN_ID}/actions/Stop`, {}, DEFAULT_TOKEN);
+    const stoppedState = await request(port, 'GET', `/v2/devices/${SIM_UP_DOWN_DIMMER_FAN_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(start.statusCode).to.equal(200);
+    expect(activeState.body).to.deep.include({
+      active_hold: 'StartUpLightDimmer',
+    });
+    expect(stop.statusCode).to.equal(200);
+    expect(stoppedState.body).not.to.have.property('active_hold');
+  });
+
   it('toggles fan direction when advertised', async () => {
     const response = await request(port, 'PUT', `/v2/devices/${SIM_DIRECTION_FAN_ID}/actions/ToggleDirection`, {}, DEFAULT_TOKEN);
     const state = await request(port, 'GET', `/v2/devices/${SIM_DIRECTION_FAN_ID}/state`, undefined, DEFAULT_TOKEN);
@@ -567,6 +628,22 @@ describe('Bond simulator', () => {
       {
         B: DEFAULT_BOND_ID,
         t: `devices/${SIM_BASIC_FIREPLACE_ID}/state`,
+        m: 4,
+        b: { power: 1 },
+      },
+    ]);
+  });
+
+  it('toggles generic power through TogglePower', async () => {
+    const response = await request(port, 'PUT', `/v2/devices/${SIM_GENERIC_ID}/actions/TogglePower`, {}, DEFAULT_TOKEN);
+    const state = await request(port, 'GET', `/v2/devices/${SIM_GENERIC_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ power: 1 });
+    expect(bpupPackets).to.deep.equal([
+      {
+        B: DEFAULT_BOND_ID,
+        t: `devices/${SIM_GENERIC_ID}/state`,
         m: 4,
         b: { power: 1 },
       },

--- a/tests/bondSimulator.spec.ts
+++ b/tests/bondSimulator.spec.ts
@@ -6,10 +6,18 @@ import {
   BpupPacket,
   DEFAULT_BOND_ID,
   DEFAULT_TOKEN,
+  SIM_BASIC_FAN_ID,
+  SIM_BRIGHTNESS_BUTTON_FAN_ID,
+  SIM_DIMMER_FAN_ID,
   SIM_DIMMABLE_LIGHT_ID,
+  SIM_DIRECTION_FAN_ID,
   SIM_LIGHT_ID,
+  SIM_LIGHT_FAN_ID,
   SIM_SET_BRIGHTNESS_ONLY_LIGHT_ID,
+  SIM_SPEED_BUTTON_FAN_ID,
   SIM_TURN_LIGHT_OFF_ONLY_LIGHT_ID,
+  SIM_UP_DOWN_DIMMER_FAN_ID,
+  SIM_UP_DOWN_LIGHT_FAN_ID,
   getServerPort,
 } from '../tools/bond-simulator/server';
 
@@ -119,6 +127,34 @@ describe('Bond simulator', () => {
     expect(dimmableLight.body.actions).to.deep.equal(['ToggleLight', 'SetBrightness', 'TurnLightOff']);
     expect(setBrightnessOnly.body.actions).to.deep.equal(['ToggleLight', 'SetBrightness']);
     expect(turnLightOffOnly.body.actions).to.deep.equal(['ToggleLight', 'TurnLightOff']);
+  });
+
+  it('returns the fan permutation catalog with expected capability shapes', async () => {
+    const list = await request(port, 'GET', '/v2/devices', undefined, DEFAULT_TOKEN);
+    const basicFan = await request(port, 'GET', `/v2/devices/${SIM_BASIC_FAN_ID}`, undefined, DEFAULT_TOKEN);
+    const speedButtonFan = await request(port, 'GET', `/v2/devices/${SIM_SPEED_BUTTON_FAN_ID}`, undefined, DEFAULT_TOKEN);
+    const upDownDimmerFan = await request(port, 'GET', `/v2/devices/${SIM_UP_DOWN_DIMMER_FAN_ID}`, undefined, DEFAULT_TOKEN);
+    const brightnessButtonFan = await request(port, 'GET', `/v2/devices/${SIM_BRIGHTNESS_BUTTON_FAN_ID}`, undefined, DEFAULT_TOKEN);
+
+    expect(list.body).to.include.keys(
+      SIM_BASIC_FAN_ID,
+      SIM_DIRECTION_FAN_ID,
+      SIM_SPEED_BUTTON_FAN_ID,
+      SIM_LIGHT_FAN_ID,
+      SIM_UP_DOWN_LIGHT_FAN_ID,
+      SIM_DIMMER_FAN_ID,
+      SIM_UP_DOWN_DIMMER_FAN_ID,
+      SIM_BRIGHTNESS_BUTTON_FAN_ID,
+    );
+    expect(basicFan.body).to.deep.include({
+      name: 'Basic Fan',
+      location: 'Simulator',
+      type: 'CF',
+    });
+    expect(basicFan.body.actions).to.deep.equal(['TurnOn', 'TurnOff', 'SetSpeed']);
+    expect(speedButtonFan.body.actions).to.deep.equal(['TurnOn', 'TurnOff', 'IncreaseSpeed', 'DecreaseSpeed']);
+    expect(upDownDimmerFan.body.actions).to.include.members(['ToggleUpLight', 'ToggleDownLight', 'StartDimmer']);
+    expect(brightnessButtonFan.body.actions).to.include.members(['StartIncreasingBrightness', 'StartDecreasingBrightness']);
   });
 
   it('rejects protected endpoints without the simulator token', async () => {
@@ -235,5 +271,99 @@ describe('Bond simulator', () => {
     );
 
     expect(response.statusCode).to.equal(404);
+  });
+
+  it('turns a fan on and off through Bond actions', async () => {
+    const turnOn = await request(port, 'PUT', `/v2/devices/${SIM_BASIC_FAN_ID}/actions/TurnOn`, {}, DEFAULT_TOKEN);
+    const onState = await request(port, 'GET', `/v2/devices/${SIM_BASIC_FAN_ID}/state`, undefined, DEFAULT_TOKEN);
+    const turnOff = await request(port, 'PUT', `/v2/devices/${SIM_BASIC_FAN_ID}/actions/TurnOff`, {}, DEFAULT_TOKEN);
+    const offState = await request(port, 'GET', `/v2/devices/${SIM_BASIC_FAN_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(turnOn.statusCode).to.equal(200);
+    expect(onState.body).to.deep.equal({ power: 1, speed: 1 });
+    expect(turnOff.statusCode).to.equal(200);
+    expect(offState.body).to.deep.equal({ power: 0, speed: 1 });
+    expect(bpupPackets.map(packet => packet.b)).to.deep.equal([
+      { power: 1, speed: 1 },
+      { power: 0, speed: 1 },
+    ]);
+  });
+
+  it('sets fan speed and broadcasts the updated fan state', async () => {
+    const response = await request(
+      port,
+      'PUT',
+      `/v2/devices/${SIM_BASIC_FAN_ID}/actions/SetSpeed`,
+      { argument: 3 },
+      DEFAULT_TOKEN,
+    );
+    const state = await request(port, 'GET', `/v2/devices/${SIM_BASIC_FAN_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ power: 1, speed: 3 });
+    expect(bpupPackets).to.deep.equal([
+      {
+        B: DEFAULT_BOND_ID,
+        t: `devices/${SIM_BASIC_FAN_ID}/state`,
+        m: 4,
+        b: { power: 1, speed: 3 },
+      },
+    ]);
+  });
+
+  it('supports fan speed increase and decrease actions', async () => {
+    const increase = await request(port, 'PUT', `/v2/devices/${SIM_SPEED_BUTTON_FAN_ID}/actions/IncreaseSpeed`, {}, DEFAULT_TOKEN);
+    const decrease = await request(port, 'PUT', `/v2/devices/${SIM_SPEED_BUTTON_FAN_ID}/actions/DecreaseSpeed`, {}, DEFAULT_TOKEN);
+    const state = await request(port, 'GET', `/v2/devices/${SIM_SPEED_BUTTON_FAN_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(increase.statusCode).to.equal(200);
+    expect(decrease.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ power: 1, speed: 1 });
+  });
+
+  it('toggles fan direction when advertised', async () => {
+    const response = await request(port, 'PUT', `/v2/devices/${SIM_DIRECTION_FAN_ID}/actions/ToggleDirection`, {}, DEFAULT_TOKEN);
+    const state = await request(port, 'GET', `/v2/devices/${SIM_DIRECTION_FAN_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ power: 0, speed: 1, direction: -1 });
+  });
+
+  it('toggles up and down fan lights independently', async () => {
+    const up = await request(port, 'PUT', `/v2/devices/${SIM_UP_DOWN_LIGHT_FAN_ID}/actions/ToggleUpLight`, {}, DEFAULT_TOKEN);
+    const down = await request(port, 'PUT', `/v2/devices/${SIM_UP_DOWN_LIGHT_FAN_ID}/actions/ToggleDownLight`, {}, DEFAULT_TOKEN);
+    const state = await request(port, 'GET', `/v2/devices/${SIM_UP_DOWN_LIGHT_FAN_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(up.statusCode).to.equal(200);
+    expect(down.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({
+      power: 0,
+      speed: 1,
+      light: 1,
+      up_light: 1,
+      down_light: 1,
+    });
+  });
+
+  it('patches fan state and broadcasts the changed fields', async () => {
+    const response = await request(
+      port,
+      'PATCH',
+      `/v2/devices/${SIM_LIGHT_FAN_ID}/state`,
+      { power: 1, speed: 2, light: 1 },
+      DEFAULT_TOKEN,
+    );
+    const state = await request(port, 'GET', `/v2/devices/${SIM_LIGHT_FAN_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ power: 1, speed: 2, light: 1 });
+    expect(bpupPackets).to.deep.equal([
+      {
+        B: DEFAULT_BOND_ID,
+        t: `devices/${SIM_LIGHT_FAN_ID}/state`,
+        m: 4,
+        b: { power: 1, speed: 2, light: 1 },
+      },
+    ]);
   });
 });

--- a/tests/bondSimulator.spec.ts
+++ b/tests/bondSimulator.spec.ts
@@ -6,6 +6,7 @@ import {
   BpupPacket,
   DEFAULT_BOND_ID,
   DEFAULT_TOKEN,
+  SIM_DIMMABLE_LIGHT_ID,
   SIM_LIGHT_ID,
   getServerPort,
 } from '../tools/bond-simulator/server';
@@ -88,19 +89,28 @@ describe('Bond simulator', () => {
     expect(response.body.api).to.equal(2);
   });
 
-  it('returns a Bond-style device list and light detail', async () => {
+  it('returns a Bond-style device list and light details', async () => {
     const list = await request(port, 'GET', '/v2/devices', undefined, DEFAULT_TOKEN);
-    const detail = await request(port, 'GET', `/v2/devices/${SIM_LIGHT_ID}`, undefined, DEFAULT_TOKEN);
+    const simpleLight = await request(port, 'GET', `/v2/devices/${SIM_LIGHT_ID}`, undefined, DEFAULT_TOKEN);
+    const dimmableLight = await request(port, 'GET', `/v2/devices/${SIM_DIMMABLE_LIGHT_ID}`, undefined, DEFAULT_TOKEN);
 
     expect(list.statusCode).to.equal(200);
     expect(list.body).to.have.property(SIM_LIGHT_ID);
-    expect(detail.statusCode).to.equal(200);
-    expect(detail.body).to.deep.include({
+    expect(list.body).to.have.property(SIM_DIMMABLE_LIGHT_ID);
+    expect(simpleLight.statusCode).to.equal(200);
+    expect(simpleLight.body).to.deep.include({
       name: 'Sim Light',
       location: 'Simulator',
       type: 'LT',
     });
-    expect(detail.body.actions).to.deep.equal(['ToggleLight']);
+    expect(simpleLight.body.actions).to.deep.equal(['ToggleLight']);
+    expect(dimmableLight.statusCode).to.equal(200);
+    expect(dimmableLight.body).to.deep.include({
+      name: 'Dimmer Light',
+      location: 'Simulator',
+      type: 'LT',
+    });
+    expect(dimmableLight.body.actions).to.deep.equal(['ToggleLight', 'SetBrightness', 'TurnLightOff']);
   });
 
   it('rejects protected endpoints without the simulator token', async () => {
@@ -147,5 +157,49 @@ describe('Bond simulator', () => {
 
     expect(response.statusCode).to.equal(200);
     expect(bpupPackets).to.deep.equal([]);
+  });
+
+  it('sets brightness and turns on the dimmable light through SetBrightness', async () => {
+    const response = await request(
+      port,
+      'PUT',
+      `/v2/devices/${SIM_DIMMABLE_LIGHT_ID}/actions/SetBrightness`,
+      { argument: 72 },
+      DEFAULT_TOKEN,
+    );
+    const state = await request(port, 'GET', `/v2/devices/${SIM_DIMMABLE_LIGHT_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ light: 1, brightness: 72 });
+    expect(bpupPackets).to.deep.equal([
+      {
+        B: DEFAULT_BOND_ID,
+        t: `devices/${SIM_DIMMABLE_LIGHT_ID}/state`,
+        m: 4,
+        b: { light: 1, brightness: 72 },
+      },
+    ]);
+  });
+
+  it('patches dimmable light brightness and broadcasts BPUP when changed', async () => {
+    const response = await request(
+      port,
+      'PATCH',
+      `/v2/devices/${SIM_DIMMABLE_LIGHT_ID}/state`,
+      { brightness: 35 },
+      DEFAULT_TOKEN,
+    );
+    const state = await request(port, 'GET', `/v2/devices/${SIM_DIMMABLE_LIGHT_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ light: 0, brightness: 35 });
+    expect(bpupPackets).to.deep.equal([
+      {
+        B: DEFAULT_BOND_ID,
+        t: `devices/${SIM_DIMMABLE_LIGHT_ID}/state`,
+        m: 4,
+        b: { light: 0, brightness: 35 },
+      },
+    ]);
   });
 });

--- a/tests/bondSimulator.spec.ts
+++ b/tests/bondSimulator.spec.ts
@@ -5,6 +5,7 @@ import {
   BondSimulatorServer,
   BpupPacket,
   DEFAULT_BOND_ID,
+  DEFAULT_DEVICE_LOCATION,
   DEFAULT_TOKEN,
   SIM_BASIC_FIREPLACE_ID,
   SIM_BASIC_FAN_ID,
@@ -119,14 +120,14 @@ describe('Bond simulator', () => {
     expect(simpleLight.statusCode).to.equal(200);
     expect(simpleLight.body).to.deep.include({
       name: 'Toggle Light',
-      location: 'Simulator',
+      location: DEFAULT_DEVICE_LOCATION,
       type: 'LT',
     });
     expect(simpleLight.body.actions).to.deep.equal(['ToggleLight']);
     expect(dimmableLight.statusCode).to.equal(200);
     expect(dimmableLight.body).to.deep.include({
       name: 'Dimmable Light',
-      location: 'Simulator',
+      location: DEFAULT_DEVICE_LOCATION,
       type: 'LT',
     });
     expect(dimmableLight.body.actions).to.deep.equal(['ToggleLight', 'SetBrightness', 'TurnLightOff']);
@@ -153,7 +154,7 @@ describe('Bond simulator', () => {
     );
     expect(basicFan.body).to.deep.include({
       name: 'Basic Fan',
-      location: 'Simulator',
+      location: DEFAULT_DEVICE_LOCATION,
       type: 'CF',
     });
     expect(basicFan.body.actions).to.deep.equal(['TurnOn', 'TurnOff', 'SetSpeed']);
@@ -175,14 +176,14 @@ describe('Bond simulator', () => {
     );
     expect(toggleShade.body).to.deep.include({
       name: 'Toggle Shade',
-      location: 'Simulator',
+      location: DEFAULT_DEVICE_LOCATION,
       type: 'MS',
     });
     expect(toggleShade.body.actions).to.deep.equal(['ToggleOpen']);
     expect(positionShade.body.actions).to.deep.equal(['ToggleOpen', 'SetPosition']);
     expect(awningShade.body).to.deep.include({
       name: 'Awning Shade With Preset',
-      location: 'Simulator',
+      location: DEFAULT_DEVICE_LOCATION,
       type: 'MS',
       subtype: 'AWNING',
     });
@@ -200,13 +201,13 @@ describe('Bond simulator', () => {
     );
     expect(basicFireplace.body).to.deep.include({
       name: 'Basic Fireplace',
-      location: 'Simulator',
+      location: DEFAULT_DEVICE_LOCATION,
       type: 'FP',
     });
     expect(basicFireplace.body.actions).to.deep.equal(['TogglePower']);
     expect(flameFireplace.body).to.deep.include({
       name: 'Flame Fireplace',
-      location: 'Simulator',
+      location: DEFAULT_DEVICE_LOCATION,
       type: 'FP',
     });
     expect(flameFireplace.body.actions).to.deep.equal(['TogglePower', 'SetFlame']);

--- a/tests/bondSimulator.spec.ts
+++ b/tests/bondSimulator.spec.ts
@@ -237,6 +237,34 @@ describe('Bond simulator', () => {
     ]);
   });
 
+  it('logs received actions and BPUP broadcasts', async () => {
+    const logs: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      server.close(error => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+
+    simulator = new BondSimulatorServer({
+      logger: message => logs.push(message),
+      broadcaster: {
+        broadcast: packet => bpupPackets.push(packet),
+      },
+    });
+    server = await simulator.listen(0);
+    port = getServerPort(server);
+
+    const action = await request(port, 'PUT', `/v2/devices/${SIM_LIGHT_ID}/actions/ToggleLight`, {}, DEFAULT_TOKEN);
+
+    expect(action.statusCode).to.equal(200);
+    expect(logs.some(log => log.includes('Toggle Light (00000001) received PUT action ToggleLight'))).to.equal(true);
+    expect(logs.some(log => log.includes('BPUP broadcast devices/00000001/state {"light":1}'))).to.equal(true);
+  });
+
   it('updates light state through PATCH and broadcasts BPUP when changed', async () => {
     const response = await request(port, 'PATCH', `/v2/devices/${SIM_LIGHT_ID}/state`, { light: 1 }, DEFAULT_TOKEN);
     const state = await request(port, 'GET', `/v2/devices/${SIM_LIGHT_ID}/state`, undefined, DEFAULT_TOKEN);

--- a/tests/bondSimulator.spec.ts
+++ b/tests/bondSimulator.spec.ts
@@ -309,6 +309,27 @@ describe('Bond simulator', () => {
     ]);
   });
 
+  it('sets brightness to 0 and turns off a dimmable light', async () => {
+    await request(
+      port,
+      'PUT',
+      `/v2/devices/${SIM_DIMMABLE_LIGHT_ID}/actions/SetBrightness`,
+      { argument: 72 },
+      DEFAULT_TOKEN,
+    );
+    const response = await request(
+      port,
+      'PUT',
+      `/v2/devices/${SIM_DIMMABLE_LIGHT_ID}/actions/SetBrightness`,
+      { argument: 0 },
+      DEFAULT_TOKEN,
+    );
+    const state = await request(port, 'GET', `/v2/devices/${SIM_DIMMABLE_LIGHT_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ light: 0, brightness: 0 });
+  });
+
   it('patches dimmable light brightness and broadcasts BPUP when changed', async () => {
     const response = await request(
       port,
@@ -393,6 +414,27 @@ describe('Bond simulator', () => {
         b: { power: 1, speed: 3 },
       },
     ]);
+  });
+
+  it('sets fan speed to 0 and turns the fan off', async () => {
+    await request(
+      port,
+      'PUT',
+      `/v2/devices/${SIM_BASIC_FAN_ID}/actions/SetSpeed`,
+      { argument: 2 },
+      DEFAULT_TOKEN,
+    );
+    const response = await request(
+      port,
+      'PUT',
+      `/v2/devices/${SIM_BASIC_FAN_ID}/actions/SetSpeed`,
+      { argument: 0 },
+      DEFAULT_TOKEN,
+    );
+    const state = await request(port, 'GET', `/v2/devices/${SIM_BASIC_FAN_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ power: 0, speed: 0 });
   });
 
   it('supports fan speed increase and decrease actions', async () => {
@@ -551,6 +593,27 @@ describe('Bond simulator', () => {
         b: { power: 1, flame: 68 },
       },
     ]);
+  });
+
+  it('sets flame to 0 and turns off the flame fireplace', async () => {
+    await request(
+      port,
+      'PUT',
+      `/v2/devices/${SIM_FLAME_FIREPLACE_ID}/actions/SetFlame`,
+      { argument: 68 },
+      DEFAULT_TOKEN,
+    );
+    const response = await request(
+      port,
+      'PUT',
+      `/v2/devices/${SIM_FLAME_FIREPLACE_ID}/actions/SetFlame`,
+      { argument: 0 },
+      DEFAULT_TOKEN,
+    );
+    const state = await request(port, 'GET', `/v2/devices/${SIM_FLAME_FIREPLACE_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ power: 0, flame: 0 });
   });
 
   it('patches flame fireplace state and broadcasts the changed fields', async () => {

--- a/tests/bondSimulator.spec.ts
+++ b/tests/bondSimulator.spec.ts
@@ -13,8 +13,11 @@ import {
   SIM_DIRECTION_FAN_ID,
   SIM_LIGHT_ID,
   SIM_LIGHT_FAN_ID,
+  SIM_AWNING_SHADE_ID,
+  SIM_POSITION_SHADE_ID,
   SIM_SET_BRIGHTNESS_ONLY_LIGHT_ID,
   SIM_SPEED_BUTTON_FAN_ID,
+  SIM_TOGGLE_SHADE_ID,
   SIM_TURN_LIGHT_OFF_ONLY_LIGHT_ID,
   SIM_UP_DOWN_DIMMER_FAN_ID,
   SIM_UP_DOWN_LIGHT_FAN_ID,
@@ -155,6 +158,33 @@ describe('Bond simulator', () => {
     expect(speedButtonFan.body.actions).to.deep.equal(['TurnOn', 'TurnOff', 'IncreaseSpeed', 'DecreaseSpeed']);
     expect(upDownDimmerFan.body.actions).to.include.members(['ToggleUpLight', 'ToggleDownLight', 'StartDimmer']);
     expect(brightnessButtonFan.body.actions).to.include.members(['StartIncreasingBrightness', 'StartDecreasingBrightness']);
+  });
+
+  it('returns the shade permutation catalog with expected capability shapes', async () => {
+    const list = await request(port, 'GET', '/v2/devices', undefined, DEFAULT_TOKEN);
+    const toggleShade = await request(port, 'GET', `/v2/devices/${SIM_TOGGLE_SHADE_ID}`, undefined, DEFAULT_TOKEN);
+    const positionShade = await request(port, 'GET', `/v2/devices/${SIM_POSITION_SHADE_ID}`, undefined, DEFAULT_TOKEN);
+    const awningShade = await request(port, 'GET', `/v2/devices/${SIM_AWNING_SHADE_ID}`, undefined, DEFAULT_TOKEN);
+
+    expect(list.body).to.include.keys(
+      SIM_TOGGLE_SHADE_ID,
+      SIM_POSITION_SHADE_ID,
+      SIM_AWNING_SHADE_ID,
+    );
+    expect(toggleShade.body).to.deep.include({
+      name: 'Toggle Shade',
+      location: 'Simulator',
+      type: 'MS',
+    });
+    expect(toggleShade.body.actions).to.deep.equal(['ToggleOpen']);
+    expect(positionShade.body.actions).to.deep.equal(['ToggleOpen', 'SetPosition']);
+    expect(awningShade.body).to.deep.include({
+      name: 'Awning Shade With Preset',
+      location: 'Simulator',
+      type: 'MS',
+      subtype: 'AWNING',
+    });
+    expect(awningShade.body.actions).to.deep.equal(['ToggleOpen', 'SetPosition', 'Preset']);
   });
 
   it('rejects protected endpoints without the simulator token', async () => {
@@ -365,5 +395,69 @@ describe('Bond simulator', () => {
         b: { power: 1, speed: 2, light: 1 },
       },
     ]);
+  });
+
+  it('toggles a shade open state through ToggleOpen', async () => {
+    const response = await request(port, 'PUT', `/v2/devices/${SIM_TOGGLE_SHADE_ID}/actions/ToggleOpen`, {}, DEFAULT_TOKEN);
+    const state = await request(port, 'GET', `/v2/devices/${SIM_TOGGLE_SHADE_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ open: 1 });
+    expect(bpupPackets).to.deep.equal([
+      {
+        B: DEFAULT_BOND_ID,
+        t: `devices/${SIM_TOGGLE_SHADE_ID}/state`,
+        m: 4,
+        b: { open: 1 },
+      },
+    ]);
+  });
+
+  it('sets normal shade position using Bond-inverted position semantics', async () => {
+    const response = await request(
+      port,
+      'PUT',
+      `/v2/devices/${SIM_POSITION_SHADE_ID}/actions/SetPosition`,
+      { argument: 25 },
+      DEFAULT_TOKEN,
+    );
+    const state = await request(port, 'GET', `/v2/devices/${SIM_POSITION_SHADE_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ open: 1, position: 25 });
+    expect(bpupPackets[0]).to.deep.include({
+      B: DEFAULT_BOND_ID,
+      t: `devices/${SIM_POSITION_SHADE_ID}/state`,
+      m: 4,
+    });
+    expect(bpupPackets[0].b).to.deep.equal({ open: 1, position: 25 });
+  });
+
+  it('toggles normal position shade between Bond closed and open positions', async () => {
+    await request(port, 'PUT', `/v2/devices/${SIM_POSITION_SHADE_ID}/actions/ToggleOpen`, {}, DEFAULT_TOKEN);
+    const openState = await request(port, 'GET', `/v2/devices/${SIM_POSITION_SHADE_ID}/state`, undefined, DEFAULT_TOKEN);
+    await request(port, 'PUT', `/v2/devices/${SIM_POSITION_SHADE_ID}/actions/ToggleOpen`, {}, DEFAULT_TOKEN);
+    const closedState = await request(port, 'GET', `/v2/devices/${SIM_POSITION_SHADE_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(openState.body).to.deep.equal({ open: 1, position: 0 });
+    expect(closedState.body).to.deep.equal({ open: 0, position: 100 });
+  });
+
+  it('uses non-inverted position semantics for awnings', async () => {
+    await request(port, 'PUT', `/v2/devices/${SIM_AWNING_SHADE_ID}/actions/ToggleOpen`, {}, DEFAULT_TOKEN);
+    const openState = await request(port, 'GET', `/v2/devices/${SIM_AWNING_SHADE_ID}/state`, undefined, DEFAULT_TOKEN);
+    await request(port, 'PUT', `/v2/devices/${SIM_AWNING_SHADE_ID}/actions/ToggleOpen`, {}, DEFAULT_TOKEN);
+    const closedState = await request(port, 'GET', `/v2/devices/${SIM_AWNING_SHADE_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(openState.body).to.deep.equal({ open: 1, position: 100 });
+    expect(closedState.body).to.deep.equal({ open: 0, position: 0 });
+  });
+
+  it('executes shade preset by moving to a middle position', async () => {
+    const response = await request(port, 'PUT', `/v2/devices/${SIM_AWNING_SHADE_ID}/actions/Preset`, {}, DEFAULT_TOKEN);
+    const state = await request(port, 'GET', `/v2/devices/${SIM_AWNING_SHADE_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ open: 1, position: 50 });
   });
 });

--- a/tests/bondSimulator.spec.ts
+++ b/tests/bondSimulator.spec.ts
@@ -6,11 +6,13 @@ import {
   BpupPacket,
   DEFAULT_BOND_ID,
   DEFAULT_TOKEN,
+  SIM_BASIC_FIREPLACE_ID,
   SIM_BASIC_FAN_ID,
   SIM_BRIGHTNESS_BUTTON_FAN_ID,
   SIM_DIMMER_FAN_ID,
   SIM_DIMMABLE_LIGHT_ID,
   SIM_DIRECTION_FAN_ID,
+  SIM_FLAME_FIREPLACE_ID,
   SIM_LIGHT_ID,
   SIM_LIGHT_FAN_ID,
   SIM_AWNING_SHADE_ID,
@@ -185,6 +187,29 @@ describe('Bond simulator', () => {
       subtype: 'AWNING',
     });
     expect(awningShade.body.actions).to.deep.equal(['ToggleOpen', 'SetPosition', 'Preset']);
+  });
+
+  it('returns the fireplace permutation catalog with expected capability shapes', async () => {
+    const list = await request(port, 'GET', '/v2/devices', undefined, DEFAULT_TOKEN);
+    const basicFireplace = await request(port, 'GET', `/v2/devices/${SIM_BASIC_FIREPLACE_ID}`, undefined, DEFAULT_TOKEN);
+    const flameFireplace = await request(port, 'GET', `/v2/devices/${SIM_FLAME_FIREPLACE_ID}`, undefined, DEFAULT_TOKEN);
+
+    expect(list.body).to.include.keys(
+      SIM_BASIC_FIREPLACE_ID,
+      SIM_FLAME_FIREPLACE_ID,
+    );
+    expect(basicFireplace.body).to.deep.include({
+      name: 'Basic Fireplace',
+      location: 'Simulator',
+      type: 'FP',
+    });
+    expect(basicFireplace.body.actions).to.deep.equal(['TogglePower']);
+    expect(flameFireplace.body).to.deep.include({
+      name: 'Flame Fireplace',
+      location: 'Simulator',
+      type: 'FP',
+    });
+    expect(flameFireplace.body.actions).to.deep.equal(['TogglePower', 'SetFlame']);
   });
 
   it('rejects protected endpoints without the simulator token', async () => {
@@ -459,5 +484,77 @@ describe('Bond simulator', () => {
 
     expect(response.statusCode).to.equal(200);
     expect(state.body).to.deep.equal({ open: 1, position: 50 });
+  });
+
+  it('toggles fireplace power through TogglePower', async () => {
+    const response = await request(port, 'PUT', `/v2/devices/${SIM_BASIC_FIREPLACE_ID}/actions/TogglePower`, {}, DEFAULT_TOKEN);
+    const state = await request(port, 'GET', `/v2/devices/${SIM_BASIC_FIREPLACE_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ power: 1 });
+    expect(bpupPackets).to.deep.equal([
+      {
+        B: DEFAULT_BOND_ID,
+        t: `devices/${SIM_BASIC_FIREPLACE_ID}/state`,
+        m: 4,
+        b: { power: 1 },
+      },
+    ]);
+  });
+
+  it('sets flame level and turns on the flame fireplace through SetFlame', async () => {
+    const response = await request(
+      port,
+      'PUT',
+      `/v2/devices/${SIM_FLAME_FIREPLACE_ID}/actions/SetFlame`,
+      { argument: 68 },
+      DEFAULT_TOKEN,
+    );
+    const state = await request(port, 'GET', `/v2/devices/${SIM_FLAME_FIREPLACE_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ power: 1, flame: 68 });
+    expect(bpupPackets).to.deep.equal([
+      {
+        B: DEFAULT_BOND_ID,
+        t: `devices/${SIM_FLAME_FIREPLACE_ID}/state`,
+        m: 4,
+        b: { power: 1, flame: 68 },
+      },
+    ]);
+  });
+
+  it('patches flame fireplace state and broadcasts the changed fields', async () => {
+    const response = await request(
+      port,
+      'PATCH',
+      `/v2/devices/${SIM_FLAME_FIREPLACE_ID}/state`,
+      { power: 1, flame: 35 },
+      DEFAULT_TOKEN,
+    );
+    const state = await request(port, 'GET', `/v2/devices/${SIM_FLAME_FIREPLACE_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ power: 1, flame: 35 });
+    expect(bpupPackets).to.deep.equal([
+      {
+        B: DEFAULT_BOND_ID,
+        t: `devices/${SIM_FLAME_FIREPLACE_ID}/state`,
+        m: 4,
+        b: { power: 1, flame: 35 },
+      },
+    ]);
+  });
+
+  it('rejects SetFlame on a fireplace that does not advertise it', async () => {
+    const response = await request(
+      port,
+      'PUT',
+      `/v2/devices/${SIM_BASIC_FIREPLACE_ID}/actions/SetFlame`,
+      { argument: 68 },
+      DEFAULT_TOKEN,
+    );
+
+    expect(response.statusCode).to.equal(404);
   });
 });

--- a/tests/bondSimulator.spec.ts
+++ b/tests/bondSimulator.spec.ts
@@ -1,0 +1,151 @@
+import { expect } from 'chai';
+import 'mocha';
+import http from 'http';
+import {
+  BondSimulatorServer,
+  BpupPacket,
+  DEFAULT_BOND_ID,
+  DEFAULT_TOKEN,
+  SIM_LIGHT_ID,
+  getServerPort,
+} from '../tools/bond-simulator/server';
+
+interface TestResponse {
+  statusCode: number;
+  body: any;
+}
+
+function request(port: number, method: string, path: string, body?: unknown, token?: string): Promise<TestResponse> {
+  const payload = body === undefined ? undefined : JSON.stringify(body);
+
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      host: '127.0.0.1',
+      port,
+      path,
+      method,
+      headers: {
+        ...(token ? { 'BOND-Token': token } : {}),
+        ...(payload ? {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload),
+        } : {}),
+      },
+    }, response => {
+      const chunks: Buffer[] = [];
+      response.on('data', chunk => chunks.push(Buffer.from(chunk)));
+      response.on('end', () => {
+        const raw = Buffer.concat(chunks).toString();
+        resolve({
+          statusCode: response.statusCode ?? 0,
+          body: raw ? JSON.parse(raw) : undefined,
+        });
+      });
+    });
+
+    req.on('error', reject);
+    if (payload) {
+      req.write(payload);
+    }
+    req.end();
+  });
+}
+
+describe('Bond simulator', () => {
+  let simulator: BondSimulatorServer;
+  let server: http.Server;
+  let port: number;
+  let bpupPackets: BpupPacket[];
+
+  beforeEach(async () => {
+    bpupPackets = [];
+    simulator = new BondSimulatorServer({
+      broadcaster: {
+        broadcast: packet => bpupPackets.push(packet),
+      },
+    });
+    server = await simulator.listen(0);
+    port = getServerPort(server);
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close(error => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  });
+
+  it('returns version information with the simulator Bond ID', async () => {
+    const response = await request(port, 'GET', '/v2/sys/version');
+
+    expect(response.statusCode).to.equal(200);
+    expect(response.body.bondid).to.equal(DEFAULT_BOND_ID);
+    expect(response.body.api).to.equal(2);
+  });
+
+  it('returns a Bond-style device list and light detail', async () => {
+    const list = await request(port, 'GET', '/v2/devices', undefined, DEFAULT_TOKEN);
+    const detail = await request(port, 'GET', `/v2/devices/${SIM_LIGHT_ID}`, undefined, DEFAULT_TOKEN);
+
+    expect(list.statusCode).to.equal(200);
+    expect(list.body).to.have.property(SIM_LIGHT_ID);
+    expect(detail.statusCode).to.equal(200);
+    expect(detail.body).to.deep.include({
+      name: 'Sim Light',
+      location: 'Simulator',
+      type: 'LT',
+    });
+    expect(detail.body.actions).to.deep.equal(['ToggleLight']);
+  });
+
+  it('rejects protected endpoints without the simulator token', async () => {
+    const missing = await request(port, 'GET', '/v2/devices');
+    const invalid = await request(port, 'GET', '/v2/devices', undefined, 'wrong-token');
+
+    expect(missing.statusCode).to.equal(401);
+    expect(invalid.statusCode).to.equal(401);
+  });
+
+  it('toggles the light through the ToggleLight action', async () => {
+    const action = await request(port, 'PUT', `/v2/devices/${SIM_LIGHT_ID}/actions/ToggleLight`, {}, DEFAULT_TOKEN);
+    const state = await request(port, 'GET', `/v2/devices/${SIM_LIGHT_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(action.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ light: 1 });
+    expect(bpupPackets).to.deep.equal([
+      {
+        B: DEFAULT_BOND_ID,
+        t: `devices/${SIM_LIGHT_ID}/state`,
+        m: 4,
+        b: { light: 1 },
+      },
+    ]);
+  });
+
+  it('updates light state through PATCH and broadcasts BPUP when changed', async () => {
+    const response = await request(port, 'PATCH', `/v2/devices/${SIM_LIGHT_ID}/state`, { light: 1 }, DEFAULT_TOKEN);
+    const state = await request(port, 'GET', `/v2/devices/${SIM_LIGHT_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ light: 1 });
+    expect(bpupPackets).to.have.length(1);
+    expect(bpupPackets[0]).to.deep.include({
+      B: DEFAULT_BOND_ID,
+      t: `devices/${SIM_LIGHT_ID}/state`,
+      m: 4,
+    });
+    expect(bpupPackets[0].b).to.deep.equal({ light: 1 });
+  });
+
+  it('does not broadcast BPUP when PATCH does not change the light state', async () => {
+    const response = await request(port, 'PATCH', `/v2/devices/${SIM_LIGHT_ID}/state`, { light: 0 }, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(bpupPackets).to.deep.equal([]);
+  });
+});

--- a/tests/bondSimulator.spec.ts
+++ b/tests/bondSimulator.spec.ts
@@ -8,6 +8,8 @@ import {
   DEFAULT_TOKEN,
   SIM_DIMMABLE_LIGHT_ID,
   SIM_LIGHT_ID,
+  SIM_SET_BRIGHTNESS_ONLY_LIGHT_ID,
+  SIM_TURN_LIGHT_OFF_ONLY_LIGHT_ID,
   getServerPort,
 } from '../tools/bond-simulator/server';
 
@@ -93,24 +95,30 @@ describe('Bond simulator', () => {
     const list = await request(port, 'GET', '/v2/devices', undefined, DEFAULT_TOKEN);
     const simpleLight = await request(port, 'GET', `/v2/devices/${SIM_LIGHT_ID}`, undefined, DEFAULT_TOKEN);
     const dimmableLight = await request(port, 'GET', `/v2/devices/${SIM_DIMMABLE_LIGHT_ID}`, undefined, DEFAULT_TOKEN);
+    const setBrightnessOnly = await request(port, 'GET', `/v2/devices/${SIM_SET_BRIGHTNESS_ONLY_LIGHT_ID}`, undefined, DEFAULT_TOKEN);
+    const turnLightOffOnly = await request(port, 'GET', `/v2/devices/${SIM_TURN_LIGHT_OFF_ONLY_LIGHT_ID}`, undefined, DEFAULT_TOKEN);
 
     expect(list.statusCode).to.equal(200);
     expect(list.body).to.have.property(SIM_LIGHT_ID);
     expect(list.body).to.have.property(SIM_DIMMABLE_LIGHT_ID);
+    expect(list.body).to.have.property(SIM_SET_BRIGHTNESS_ONLY_LIGHT_ID);
+    expect(list.body).to.have.property(SIM_TURN_LIGHT_OFF_ONLY_LIGHT_ID);
     expect(simpleLight.statusCode).to.equal(200);
     expect(simpleLight.body).to.deep.include({
-      name: 'Sim Light',
+      name: 'Toggle Light',
       location: 'Simulator',
       type: 'LT',
     });
     expect(simpleLight.body.actions).to.deep.equal(['ToggleLight']);
     expect(dimmableLight.statusCode).to.equal(200);
     expect(dimmableLight.body).to.deep.include({
-      name: 'Dimmer Light',
+      name: 'Dimmable Light',
       location: 'Simulator',
       type: 'LT',
     });
     expect(dimmableLight.body.actions).to.deep.equal(['ToggleLight', 'SetBrightness', 'TurnLightOff']);
+    expect(setBrightnessOnly.body.actions).to.deep.equal(['ToggleLight', 'SetBrightness']);
+    expect(turnLightOffOnly.body.actions).to.deep.equal(['ToggleLight', 'TurnLightOff']);
   });
 
   it('rejects protected endpoints without the simulator token', async () => {
@@ -201,5 +209,31 @@ describe('Bond simulator', () => {
         b: { light: 0, brightness: 35 },
       },
     ]);
+  });
+
+  it('supports SetBrightness on the partial brightness light for negative HomeKit capability testing', async () => {
+    const response = await request(
+      port,
+      'PUT',
+      `/v2/devices/${SIM_SET_BRIGHTNESS_ONLY_LIGHT_ID}/actions/SetBrightness`,
+      { argument: 62 },
+      DEFAULT_TOKEN,
+    );
+    const state = await request(port, 'GET', `/v2/devices/${SIM_SET_BRIGHTNESS_ONLY_LIGHT_ID}/state`, undefined, DEFAULT_TOKEN);
+
+    expect(response.statusCode).to.equal(200);
+    expect(state.body).to.deep.equal({ light: 1, brightness: 62 });
+  });
+
+  it('rejects SetBrightness on a light that does not advertise it', async () => {
+    const response = await request(
+      port,
+      'PUT',
+      `/v2/devices/${SIM_TURN_LIGHT_OFF_ONLY_LIGHT_ID}/actions/SetBrightness`,
+      { argument: 62 },
+      DEFAULT_TOKEN,
+    );
+
+    expect(response.statusCode).to.equal(404);
   });
 });

--- a/tests/platform.spec.ts
+++ b/tests/platform.spec.ts
@@ -113,4 +113,76 @@ describe('BondPlatform security hardening', () => {
     const malformedLog = debugCalls.find(args => args[0]?.includes('Malformed UDP payload'));
     expect(malformedLog).to.not.be.undefined;
   });
+
+  it('strips HTTP port from BPUP UDP host', () => {
+    const log = createMockLog();
+    const api = createMockApi() as any;
+    const config = {
+      include_dimmer: false,
+      fan_speed_values: false,
+      include_toggle_state: false,
+      bonds: [{ ip_address: '127.0.0.1:18080', token: 'token' }],
+    } as any;
+
+    const platform = new BondPlatform(log as any, config, api);
+    const fakeSocket = {
+      send: sinon.stub().callsFake((
+        _message: Buffer,
+        _offset: number,
+        _length: number,
+        _port: number,
+        _host: string,
+        callback: (error?: Error) => void,
+      ) => callback()),
+      on: sinon.stub(),
+    };
+
+    sinon.stub(dgram, 'createSocket').returns(fakeSocket as any);
+    sinon.stub(global, 'setInterval').returns(1 as any);
+    const bond = {
+      config: { ip_address: '127.0.0.1:18080' },
+      receivedBPUPPacket: sinon.stub(),
+    };
+
+    (platform as any).setupBPUP(bond);
+
+    expect(fakeSocket.send.firstCall.args[3]).to.equal(30007);
+    expect(fakeSocket.send.firstCall.args[4]).to.equal('127.0.0.1');
+  });
+
+  it('logs BPUP UDP send errors without throwing', () => {
+    const log = createMockLog();
+    const api = createMockApi() as any;
+    const config = {
+      include_dimmer: false,
+      fan_speed_values: false,
+      include_toggle_state: false,
+      bonds: [{ ip_address: '127.0.0.1:18080', token: 'token' }],
+    } as any;
+
+    const platform = new BondPlatform(log as any, config, api);
+    const fakeSocket = {
+      send: sinon.stub().callsFake((
+        _message: Buffer,
+        _offset: number,
+        _length: number,
+        _port: number,
+        _host: string,
+        callback: (error?: Error) => void,
+      ) => callback(new Error('send failed'))),
+      on: sinon.stub(),
+    };
+
+    sinon.stub(dgram, 'createSocket').returns(fakeSocket as any);
+    sinon.stub(global, 'setInterval').returns(1 as any);
+    const bond = {
+      config: { ip_address: '127.0.0.1:18080' },
+      receivedBPUPPacket: sinon.stub(),
+    };
+
+    expect(() => (platform as any).setupBPUP(bond)).to.not.throw();
+    const errorCalls = log.error.args as string[][];
+    const udpError = errorCalls.find(args => args[0]?.includes('Error sending UDP message'));
+    expect(udpError).to.not.be.undefined;
+  });
 });

--- a/tools/bond-simulator/bpup.ts
+++ b/tools/bond-simulator/bpup.ts
@@ -1,5 +1,5 @@
 import dgram from 'dgram';
-import { BpupBroadcaster, BpupPacket, DEFAULT_BPUP_PORT } from './server';
+import { BpupBroadcaster, BpupPacket, DEFAULT_BPUP_PORT, SimulatorLogger } from './server';
 
 interface BpupClient {
   address: string;
@@ -11,14 +11,20 @@ export class UdpBpupBroadcaster implements BpupBroadcaster {
   private readonly socket = dgram.createSocket('udp4');
   private readonly clients = new Map<string, BpupClient>();
 
+  constructor(private readonly logger: SimulatorLogger = () => undefined) {}
+
   public async listen(port = DEFAULT_BPUP_PORT) {
     this.socket.on('message', (_message, remote) => {
       const key = `${remote.address}:${remote.port}`;
+      const hadClient = this.clients.has(key);
       this.clients.set(key, {
         address: remote.address,
         port: remote.port,
         lastSeen: Date.now(),
       });
+      if (!hadClient) {
+        this.logger(`BPUP keepalive registered ${key}`);
+      }
     });
 
     await new Promise<void>((resolve, reject) => {
@@ -33,15 +39,23 @@ export class UdpBpupBroadcaster implements BpupBroadcaster {
   public broadcast(packet: BpupPacket) {
     const message = Buffer.from(JSON.stringify(packet));
     const staleBefore = Date.now() - 1000 * 60 * 5;
+    let sendCount = 0;
 
     this.clients.forEach((client, key) => {
       if (client.lastSeen < staleBefore) {
         this.clients.delete(key);
+        this.logger(`BPUP client expired ${key}`);
         return;
       }
 
       this.socket.send(message, client.port, client.address);
+      sendCount += 1;
+      this.logger(`BPUP sent ${packet.t} to ${key}`);
     });
+
+    if (sendCount === 0) {
+      this.logger(`BPUP no clients for ${packet.t}`);
+    }
   }
 
   public close() {

--- a/tools/bond-simulator/bpup.ts
+++ b/tools/bond-simulator/bpup.ts
@@ -1,0 +1,50 @@
+import dgram from 'dgram';
+import { BpupBroadcaster, BpupPacket, DEFAULT_BPUP_PORT } from './server';
+
+interface BpupClient {
+  address: string;
+  port: number;
+  lastSeen: number;
+}
+
+export class UdpBpupBroadcaster implements BpupBroadcaster {
+  private readonly socket = dgram.createSocket('udp4');
+  private readonly clients = new Map<string, BpupClient>();
+
+  public async listen(port = DEFAULT_BPUP_PORT) {
+    this.socket.on('message', (_message, remote) => {
+      const key = `${remote.address}:${remote.port}`;
+      this.clients.set(key, {
+        address: remote.address,
+        port: remote.port,
+        lastSeen: Date.now(),
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      this.socket.once('error', reject);
+      this.socket.bind(port, () => {
+        this.socket.off('error', reject);
+        resolve();
+      });
+    });
+  }
+
+  public broadcast(packet: BpupPacket) {
+    const message = Buffer.from(JSON.stringify(packet));
+    const staleBefore = Date.now() - 1000 * 60 * 5;
+
+    this.clients.forEach((client, key) => {
+      if (client.lastSeen < staleBefore) {
+        this.clients.delete(key);
+        return;
+      }
+
+      this.socket.send(message, client.port, client.address);
+    });
+  }
+
+  public close() {
+    this.socket.close();
+  }
+}

--- a/tools/bond-simulator/cli.ts
+++ b/tools/bond-simulator/cli.ts
@@ -1,0 +1,28 @@
+import { BondSimulatorServer, DEFAULT_BPUP_PORT, DEFAULT_HTTP_PORT, DEFAULT_BOND_ID, DEFAULT_TOKEN } from './server';
+import { UdpBpupBroadcaster } from './bpup';
+
+async function main() {
+  const port = Number(process.env.BOND_SIMULATOR_PORT ?? DEFAULT_HTTP_PORT);
+  const token = process.env.BOND_SIMULATOR_TOKEN ?? DEFAULT_TOKEN;
+  const bondId = process.env.BOND_SIMULATOR_BOND_ID ?? DEFAULT_BOND_ID;
+  const broadcaster = new UdpBpupBroadcaster();
+
+  await broadcaster.listen(DEFAULT_BPUP_PORT);
+
+  const simulator = new BondSimulatorServer({
+    token,
+    bondId,
+    broadcaster,
+  });
+
+  await simulator.listen(port);
+
+  console.log(`Bond simulator UI: http://127.0.0.1:${port}/`);
+  console.log(`Homebridge Bond config: { "ip_address": "127.0.0.1:${port}", "token": "${token}" }`);
+  console.log(`BPUP UDP listening on port ${DEFAULT_BPUP_PORT}`);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tools/bond-simulator/cli.ts
+++ b/tools/bond-simulator/cli.ts
@@ -1,11 +1,15 @@
 import { BondSimulatorServer, DEFAULT_BPUP_PORT, DEFAULT_HTTP_PORT, DEFAULT_BOND_ID, DEFAULT_TOKEN } from './server';
 import { UdpBpupBroadcaster } from './bpup';
 
+function log(message: string) {
+  process.stdout.write(`[${new Date().toISOString()}] ${message}\n`);
+}
+
 async function main() {
   const port = Number(process.env.BOND_SIMULATOR_PORT ?? DEFAULT_HTTP_PORT);
   const token = process.env.BOND_SIMULATOR_TOKEN ?? DEFAULT_TOKEN;
   const bondId = process.env.BOND_SIMULATOR_BOND_ID ?? DEFAULT_BOND_ID;
-  const broadcaster = new UdpBpupBroadcaster();
+  const broadcaster = new UdpBpupBroadcaster(log);
 
   await broadcaster.listen(DEFAULT_BPUP_PORT);
 
@@ -13,16 +17,17 @@ async function main() {
     token,
     bondId,
     broadcaster,
+    logger: log,
   });
 
   await simulator.listen(port);
 
-  console.log(`Bond simulator UI: http://127.0.0.1:${port}/`);
-  console.log(`Homebridge Bond config: { "ip_address": "127.0.0.1:${port}", "token": "${token}" }`);
-  console.log(`BPUP UDP listening on port ${DEFAULT_BPUP_PORT}`);
+  log(`Bond simulator UI: http://127.0.0.1:${port}/`);
+  log(`Homebridge Bond config: { "ip_address": "127.0.0.1:${port}", "token": "${token}" }`);
+  log(`BPUP UDP listening on port ${DEFAULT_BPUP_PORT}`);
 }
 
 main().catch(error => {
-  console.error(error);
+  process.stderr.write(`${error instanceof Error ? error.stack : error}\n`);
   process.exit(1);
 });

--- a/tools/bond-simulator/server.ts
+++ b/tools/bond-simulator/server.ts
@@ -1,0 +1,343 @@
+import { IncomingMessage, ServerResponse, createServer } from 'http';
+import { AddressInfo } from 'net';
+import { readFile } from 'fs/promises';
+import { extname, join, normalize } from 'path';
+
+export const DEFAULT_HTTP_PORT = 18080;
+export const DEFAULT_BPUP_PORT = 30007;
+export const DEFAULT_TOKEN = 'sim-token';
+export const DEFAULT_BOND_ID = 'SIMBOND000001';
+export const SIM_LIGHT_ID = '00000001';
+
+type JsonObject = Record<string, unknown>;
+
+export interface BpupPacket {
+  B: string;
+  t: string;
+  m: number;
+  b: JsonObject;
+}
+
+export interface BpupBroadcaster {
+  broadcast(packet: BpupPacket): void;
+}
+
+export interface BondSimulatorOptions {
+  bondId?: string;
+  token?: string;
+  staticDir?: string;
+  broadcaster?: BpupBroadcaster;
+}
+
+interface SimulatorDevice {
+  id: string;
+  name: string;
+  location: string;
+  type: string;
+  actions: string[];
+  properties: {
+    trust_state: boolean;
+    max_speed: null;
+  };
+  state: {
+    light: number;
+  };
+}
+
+const NOOP_BROADCASTER: BpupBroadcaster = {
+  broadcast: () => undefined,
+};
+
+const MIME_TYPES: Record<string, string> = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+};
+
+export class BondSimulatorServer {
+  public readonly bondId: string;
+  public readonly token: string;
+  public readonly staticDir: string;
+  private readonly broadcaster: BpupBroadcaster;
+  private readonly device: SimulatorDevice;
+  private httpHost = '127.0.0.1';
+  private httpPort = DEFAULT_HTTP_PORT;
+
+  constructor(options: BondSimulatorOptions = {}) {
+    this.bondId = options.bondId ?? DEFAULT_BOND_ID;
+    this.token = options.token ?? DEFAULT_TOKEN;
+    this.staticDir = options.staticDir ?? join(__dirname, 'static');
+    this.broadcaster = options.broadcaster ?? NOOP_BROADCASTER;
+    this.device = {
+      id: SIM_LIGHT_ID,
+      name: 'Sim Light',
+      location: 'Simulator',
+      type: 'LT',
+      actions: ['ToggleLight'],
+      properties: {
+        trust_state: true,
+        max_speed: null,
+      },
+      state: {
+        light: 0,
+      },
+    };
+  }
+
+  public createHttpServer() {
+    return createServer((request, response) => {
+      this.handleRequest(request, response).catch(error => {
+        this.sendJson(response, 500, {
+          error: 'internal_error',
+          message: error instanceof Error ? error.message : 'Unknown error',
+        });
+      });
+    });
+  }
+
+  public async listen(port = DEFAULT_HTTP_PORT, host = '127.0.0.1') {
+    const server = this.createHttpServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(port, host, () => {
+        server.off('error', reject);
+        this.httpHost = host;
+        this.httpPort = getServerPort(server);
+        resolve();
+      });
+    });
+
+    return server;
+  }
+
+  public getState() {
+    return { ...this.device.state };
+  }
+
+  public getDevice() {
+    return {
+      name: this.device.name,
+      location: this.device.location,
+      type: this.device.type,
+      actions: [...this.device.actions],
+      properties: {},
+      state: {},
+    };
+  }
+
+  private async handleRequest(request: IncomingMessage, response: ServerResponse) {
+    const requestUrl = new URL(request.url ?? '/', 'http://localhost');
+    const pathname = requestUrl.pathname;
+
+    if (request.method === 'GET' && pathname === '/') {
+      await this.serveStaticFile(response, 'index.html');
+      return;
+    }
+
+    if (request.method === 'GET' && pathname.startsWith('/static/')) {
+      await this.serveStaticFile(response, pathname.replace('/static/', ''));
+      return;
+    }
+
+    if (pathname.startsWith('/v2/') && !this.isPublicBondEndpoint(request.method, pathname) && !this.isAuthorized(request)) {
+      this.sendJson(response, 401, { error: 'unauthorized' });
+      return;
+    }
+
+    if (request.method === 'GET' && pathname === '/v2/sys/version') {
+      this.sendJson(response, 200, this.versionBody());
+      return;
+    }
+
+    if (request.method === 'GET' && pathname === '/v2/devices') {
+      this.sendJson(response, 200, { _: this.hash(), [this.device.id]: { _: this.hash() } });
+      return;
+    }
+
+    if (request.method === 'GET' && pathname === `/v2/devices/${this.device.id}`) {
+      this.sendJson(response, 200, this.getDevice());
+      return;
+    }
+
+    if (request.method === 'GET' && pathname === `/v2/devices/${this.device.id}/properties`) {
+      this.sendJson(response, 200, this.device.properties);
+      return;
+    }
+
+    if (request.method === 'GET' && pathname === `/v2/devices/${this.device.id}/state`) {
+      this.sendJson(response, 200, this.device.state);
+      return;
+    }
+
+    if (request.method === 'PATCH' && pathname === `/v2/devices/${this.device.id}/state`) {
+      const body = await this.readJsonBody(request);
+      const changed = this.patchState(body);
+      if (changed) {
+        this.broadcastState();
+      }
+      this.sendJson(response, 200, {});
+      return;
+    }
+
+    if (request.method === 'PUT' && pathname === `/v2/devices/${this.device.id}/actions/ToggleLight`) {
+      this.setLight(this.device.state.light === 1 ? 0 : 1);
+      this.sendJson(response, 200, {});
+      return;
+    }
+
+    if (pathname === '/v2/api/bpup') {
+      this.handleBpupConfig(request, response);
+      return;
+    }
+
+    if (request.method === 'GET' && pathname === '/simulator/status') {
+      this.sendJson(response, 200, this.simulatorStatus());
+      return;
+    }
+
+    if (request.method === 'PUT' && pathname === '/simulator/toggle') {
+      this.setLight(this.device.state.light === 1 ? 0 : 1);
+      this.sendJson(response, 200, this.simulatorStatus());
+      return;
+    }
+
+    this.sendJson(response, 404, { error: 'not_found' });
+  }
+
+  private isPublicBondEndpoint(method: string | undefined, pathname: string) {
+    return method === 'GET' && pathname === '/v2/sys/version';
+  }
+
+  private isAuthorized(request: IncomingMessage) {
+    return request.headers['bond-token'] === this.token;
+  }
+
+  private handleBpupConfig(request: IncomingMessage, response: ServerResponse) {
+    if (request.method === 'GET') {
+      this.sendJson(response, 200, { broadcast: true });
+      return;
+    }
+
+    if (request.method === 'PATCH') {
+      this.sendJson(response, 200, {});
+      return;
+    }
+
+    if (request.method === 'DELETE') {
+      response.writeHead(204);
+      response.end();
+      return;
+    }
+
+    this.sendJson(response, 405, { error: 'method_not_allowed' });
+  }
+
+  private patchState(body: JsonObject) {
+    const current = this.device.state.light;
+    if (body.light !== 0 && body.light !== 1) {
+      return false;
+    }
+
+    this.device.state.light = body.light;
+    return current !== body.light;
+  }
+
+  private setLight(value: number) {
+    this.device.state.light = value;
+    this.broadcastState();
+  }
+
+  private broadcastState() {
+    this.broadcaster.broadcast({
+      B: this.bondId,
+      t: `devices/${this.device.id}/state`,
+      m: 4,
+      b: this.getState(),
+    });
+  }
+
+  private versionBody() {
+    return {
+      api: 2,
+      bondid: this.bondId,
+      fw_ver: 'v2.999.0-simulator',
+      target: 'simulator',
+      make: 'homebridge-bond',
+      model: 'Bond Simulator',
+    };
+  }
+
+  private simulatorStatus() {
+    return {
+      version: this.versionBody(),
+      token: this.token,
+      device: {
+        id: this.device.id,
+        ...this.getDevice(),
+        properties: this.device.properties,
+        state: this.getState(),
+      },
+      homebridgeConfig: {
+        platform: 'Bond',
+        bonds: [
+          {
+            ip_address: this.displayAddress(),
+            token: this.token,
+          },
+        ],
+      },
+    };
+  }
+
+  private displayAddress() {
+    const host = this.httpHost === '0.0.0.0' ? '127.0.0.1' : this.httpHost;
+    return `${host}:${this.httpPort}`;
+  }
+
+  private hash() {
+    return Math.random().toString(16).slice(2, 10).padEnd(8, '0');
+  }
+
+  private async readJsonBody(request: IncomingMessage): Promise<JsonObject> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+
+    const raw = Buffer.concat(chunks).toString().trim();
+    if (!raw) {
+      return {};
+    }
+
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('JSON body must be an object');
+    }
+    return parsed as JsonObject;
+  }
+
+  private sendJson(response: ServerResponse, statusCode: number, body: unknown) {
+    response.writeHead(statusCode, {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+    });
+    response.end(JSON.stringify(body));
+  }
+
+  private async serveStaticFile(response: ServerResponse, filePath: string) {
+    const safePath = normalize(filePath).replace(/^(\.\.(\/|\\|$))+/, '');
+    const absolutePath = join(this.staticDir, safePath);
+    const body = await readFile(absolutePath);
+    response.writeHead(200, {
+      'Content-Type': MIME_TYPES[extname(absolutePath)] ?? 'application/octet-stream',
+      'Cache-Control': 'no-store',
+    });
+    response.end(body);
+  }
+}
+
+export function getServerPort(server: ReturnType<BondSimulatorServer['createHttpServer']>) {
+  const address = server.address() as AddressInfo;
+  return address.port;
+}

--- a/tools/bond-simulator/server.ts
+++ b/tools/bond-simulator/server.ts
@@ -22,6 +22,8 @@ export const SIM_BRIGHTNESS_BUTTON_FAN_ID = '00000108';
 export const SIM_TOGGLE_SHADE_ID = '00000201';
 export const SIM_POSITION_SHADE_ID = '00000202';
 export const SIM_AWNING_SHADE_ID = '00000203';
+export const SIM_BASIC_FIREPLACE_ID = '00000301';
+export const SIM_FLAME_FIREPLACE_ID = '00000302';
 
 type JsonObject = Record<string, unknown>;
 
@@ -64,6 +66,7 @@ interface SimulatorDevice {
     down_light?: number;
     open?: number;
     position?: number;
+    flame?: number;
   };
 }
 
@@ -341,6 +344,33 @@ export class BondSimulatorServer {
           position: 0,
         },
       },
+      {
+        id: SIM_BASIC_FIREPLACE_ID,
+        name: 'Basic Fireplace',
+        location: 'Simulator',
+        type: 'FP',
+        actions: ['TogglePower'],
+        properties: {
+          trust_state: true,
+        },
+        state: {
+          power: 0,
+        },
+      },
+      {
+        id: SIM_FLAME_FIREPLACE_ID,
+        name: 'Flame Fireplace',
+        location: 'Simulator',
+        type: 'FP',
+        actions: ['TogglePower', 'SetFlame'],
+        properties: {
+          trust_state: true,
+        },
+        state: {
+          power: 0,
+          flame: 50,
+        },
+      },
     ];
   }
 
@@ -615,6 +645,14 @@ export class BondSimulatorServer {
       return this.setPosition(deviceId, 50);
     }
 
+    if (actionName === 'TogglePower') {
+      return this.togglePower(deviceId);
+    }
+
+    if (actionName === 'SetFlame' && typeof body.argument === 'number') {
+      return this.setFlame(deviceId, body.argument);
+    }
+
     if (this.isHoldAction(actionName)) {
       return true;
     }
@@ -749,9 +787,36 @@ export class BondSimulatorServer {
     return true;
   }
 
+  private togglePower(deviceId: string) {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device || device.state.power === undefined) {
+      return false;
+    }
+
+    device.state.power = device.state.power === 1 ? 0 : 1;
+    this.broadcastState(device.id);
+    return true;
+  }
+
+  private setFlame(deviceId: string, value: number) {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device || device.state.flame === undefined) {
+      return false;
+    }
+
+    device.state.flame = this.normalizePercent(value);
+    device.state.power = 1;
+    this.broadcastState(device.id);
+    return true;
+  }
+
   private patchStateField(device: SimulatorDevice, key: string, value: unknown) {
     if (key === 'brightness' && typeof value === 'number' && device.state.brightness !== undefined) {
       return this.setStateNumber(device, key, this.normalizeBrightness(value));
+    }
+
+    if (key === 'flame' && typeof value === 'number' && device.state.flame !== undefined) {
+      return this.setStateNumber(device, key, this.normalizePercent(value));
     }
 
     if (key === 'speed' && typeof value === 'number' && device.state.speed !== undefined) {
@@ -800,7 +865,7 @@ export class BondSimulatorServer {
   }
 
   private normalizeBrightness(value: number) {
-    return Math.min(100, Math.max(1, Math.round(value)));
+    return this.normalizePercent(value);
   }
 
   private normalizePosition(value: number) {
@@ -810,6 +875,10 @@ export class BondSimulatorServer {
   private normalizeSpeed(device: SimulatorDevice, value: number) {
     const maxSpeed = typeof device.properties.max_speed === 'number' ? device.properties.max_speed : 6;
     return Math.min(maxSpeed, Math.max(1, Math.round(value)));
+  }
+
+  private normalizePercent(value: number) {
+    return Math.min(100, Math.max(1, Math.round(value)));
   }
 
   private shadePositionForOpen(device: SimulatorDevice, open: number) {

--- a/tools/bond-simulator/server.ts
+++ b/tools/bond-simulator/server.ts
@@ -9,6 +9,8 @@ export const DEFAULT_TOKEN = 'sim-token';
 export const DEFAULT_BOND_ID = 'SIMBOND000001';
 export const SIM_LIGHT_ID = '00000001';
 export const SIM_DIMMABLE_LIGHT_ID = '00000002';
+export const SIM_SET_BRIGHTNESS_ONLY_LIGHT_ID = '00000003';
+export const SIM_TURN_LIGHT_OFF_ONLY_LIGHT_ID = '00000004';
 
 type JsonObject = Record<string, unknown>;
 
@@ -74,7 +76,7 @@ export class BondSimulatorServer {
     this.devices = [
       {
         id: SIM_LIGHT_ID,
-        name: 'Sim Light',
+        name: 'Toggle Light',
         location: 'Simulator',
         type: 'LT',
         actions: ['ToggleLight'],
@@ -88,7 +90,7 @@ export class BondSimulatorServer {
       },
       {
         id: SIM_DIMMABLE_LIGHT_ID,
-        name: 'Dimmer Light',
+        name: 'Dimmable Light',
         location: 'Simulator',
         type: 'LT',
         actions: ['ToggleLight', 'SetBrightness', 'TurnLightOff'],
@@ -99,6 +101,35 @@ export class BondSimulatorServer {
         state: {
           light: 0,
           brightness: 50,
+        },
+      },
+      {
+        id: SIM_SET_BRIGHTNESS_ONLY_LIGHT_ID,
+        name: 'Set Brightness Only Light',
+        location: 'Simulator',
+        type: 'LT',
+        actions: ['ToggleLight', 'SetBrightness'],
+        properties: {
+          trust_state: true,
+          max_speed: null,
+        },
+        state: {
+          light: 0,
+          brightness: 50,
+        },
+      },
+      {
+        id: SIM_TURN_LIGHT_OFF_ONLY_LIGHT_ID,
+        name: 'Turn Light Off Only Light',
+        location: 'Simulator',
+        type: 'LT',
+        actions: ['ToggleLight', 'TurnLightOff'],
+        properties: {
+          trust_state: true,
+          max_speed: null,
+        },
+        state: {
+          light: 0,
         },
       },
     ];
@@ -299,6 +330,11 @@ export class BondSimulatorServer {
   }
 
   private handleAction(deviceId: string, actionName: string, body: JsonObject) {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device || !device.actions.includes(actionName)) {
+      return false;
+    }
+
     if (actionName === 'ToggleLight') {
       return this.toggleLight(deviceId);
     }

--- a/tools/bond-simulator/server.ts
+++ b/tools/bond-simulator/server.ts
@@ -39,11 +39,14 @@ export interface BpupBroadcaster {
   broadcast(packet: BpupPacket): void;
 }
 
+export type SimulatorLogger = (message: string) => void;
+
 export interface BondSimulatorOptions {
   bondId?: string;
   token?: string;
   staticDir?: string;
   broadcaster?: BpupBroadcaster;
+  logger?: SimulatorLogger;
 }
 
 interface SimulatorDevice {
@@ -74,6 +77,7 @@ interface SimulatorDevice {
 const NOOP_BROADCASTER: BpupBroadcaster = {
   broadcast: () => undefined,
 };
+const NOOP_LOGGER: SimulatorLogger = () => undefined;
 
 const MIME_TYPES: Record<string, string> = {
   '.css': 'text/css; charset=utf-8',
@@ -87,6 +91,7 @@ export class BondSimulatorServer {
   public readonly token: string;
   public readonly staticDir: string;
   private readonly broadcaster: BpupBroadcaster;
+  private readonly logger: SimulatorLogger;
   private readonly devices: SimulatorDevice[];
   private httpHost = '127.0.0.1';
   private httpPort = DEFAULT_HTTP_PORT;
@@ -96,6 +101,7 @@ export class BondSimulatorServer {
     this.token = options.token ?? DEFAULT_TOKEN;
     this.staticDir = options.staticDir ?? join(__dirname, 'static');
     this.broadcaster = options.broadcaster ?? NOOP_BROADCASTER;
+    this.logger = options.logger ?? NOOP_LOGGER;
     this.devices = [
       {
         id: SIM_LIGHT_ID,
@@ -567,6 +573,7 @@ export class BondSimulatorServer {
     if (request.method === 'PATCH' && child === 'state') {
       const body = await this.readJsonBody(request);
       const changed = this.patchState(device.id, body);
+      this.logDeviceEvent(device, `PATCH state ${JSON.stringify(body)}${changed ? '' : ' (no change)'}`);
       if (changed) {
         this.broadcastState(device.id);
       }
@@ -576,7 +583,11 @@ export class BondSimulatorServer {
 
     if (request.method === 'PUT' && child === 'actions' && actionName) {
       const body = await this.readJsonBody(request);
+      this.logDeviceEvent(device, `received PUT action ${actionName}${this.formatBody(body)}`);
       const handled = this.handleAction(device.id, actionName, body);
+      if (!handled) {
+        this.logDeviceEvent(device, `unsupported PUT action ${actionName}${this.formatBody(body)}`);
+      }
       this.sendJson(response, handled ? 200 : 404, handled ? {} : { error: 'not_found' });
       return;
     }
@@ -853,12 +864,22 @@ export class BondSimulatorServer {
   }
 
   private broadcastState(deviceId: string) {
-    this.broadcaster.broadcast({
+    const packet = {
       B: this.bondId,
       t: `devices/${deviceId}/state`,
       m: 4,
       b: this.getState(deviceId),
-    });
+    };
+    this.logger(`BPUP broadcast ${packet.t} ${JSON.stringify(packet.b)}`);
+    this.broadcaster.broadcast(packet);
+  }
+
+  private logDeviceEvent(device: SimulatorDevice, message: string) {
+    this.logger(`${device.name} (${device.id}) ${message}; state=${JSON.stringify(device.state)}`);
+  }
+
+  private formatBody(body: JsonObject) {
+    return Object.keys(body).length === 0 ? '' : ` ${JSON.stringify(body)}`;
   }
 
   private getSimulatorDevice(id: string) {

--- a/tools/bond-simulator/server.ts
+++ b/tools/bond-simulator/server.ts
@@ -72,6 +72,8 @@ interface SimulatorDevice {
     position?: number;
     flame?: number;
   };
+  lastUpdatedAt?: number;
+  lastUpdatedBy?: 'external' | 'ui';
 }
 
 const NOOP_BROADCASTER: BpupBroadcaster = {
@@ -479,7 +481,9 @@ export class BondSimulatorServer {
 
     if (request.method === 'PUT' && pathname === '/simulator/toggle') {
       const id = requestUrl.searchParams.get('id') ?? SIM_LIGHT_ID;
-      this.toggleLight(id);
+      if (this.toggleLight(id)) {
+        this.markDeviceUpdated(id, 'ui');
+      }
       this.sendJson(response, 200, this.simulatorStatus());
       return;
     }
@@ -493,6 +497,9 @@ export class BondSimulatorServer {
         return;
       }
       const handled = this.setBrightness(id, brightness);
+      if (handled) {
+        this.markDeviceUpdated(id, 'ui');
+      }
       this.sendJson(response, handled ? 200 : 404, handled ? this.simulatorStatus() : { error: 'not_found' });
       return;
     }
@@ -507,6 +514,9 @@ export class BondSimulatorServer {
       }
 
       const handled = this.handleAction(id, action, body);
+      if (handled) {
+        this.markDeviceUpdated(id, 'ui');
+      }
       this.sendJson(response, handled ? 200 : 404, handled ? this.simulatorStatus() : { error: 'not_found' });
       return;
     }
@@ -575,6 +585,7 @@ export class BondSimulatorServer {
       const changed = this.patchState(device.id, body);
       this.logDeviceEvent(device, `PATCH state ${JSON.stringify(body)}${changed ? '' : ' (no change)'}`);
       if (changed) {
+        this.markDeviceUpdated(device.id, 'external');
         this.broadcastState(device.id);
       }
       this.sendJson(response, 200, {});
@@ -585,6 +596,9 @@ export class BondSimulatorServer {
       const body = await this.readJsonBody(request);
       this.logDeviceEvent(device, `received PUT action ${actionName}${this.formatBody(body)}`);
       const handled = this.handleAction(device.id, actionName, body);
+      if (handled) {
+        this.markDeviceUpdated(device.id, 'external');
+      }
       if (!handled) {
         this.logDeviceEvent(device, `unsupported PUT action ${actionName}${this.formatBody(body)}`);
       }
@@ -710,7 +724,7 @@ export class BondSimulatorServer {
     }
 
     device.state.brightness = this.normalizeBrightness(value);
-    device.state.light = 1;
+    device.state.light = device.state.brightness > 0 ? 1 : 0;
     this.broadcastState(device.id);
     return true;
   }
@@ -734,7 +748,7 @@ export class BondSimulatorServer {
 
     device.state.speed = this.normalizeSpeed(device, value);
     if (device.state.power !== undefined) {
-      device.state.power = 1;
+      device.state.power = device.state.speed > 0 ? 1 : 0;
     }
     this.broadcastState(device.id);
     return true;
@@ -817,7 +831,7 @@ export class BondSimulatorServer {
     }
 
     device.state.flame = this.normalizePercent(value);
-    device.state.power = 1;
+    device.state.power = device.state.flame > 0 ? 1 : 0;
     this.broadcastState(device.id);
     return true;
   }
@@ -896,11 +910,11 @@ export class BondSimulatorServer {
 
   private normalizeSpeed(device: SimulatorDevice, value: number) {
     const maxSpeed = typeof device.properties.max_speed === 'number' ? device.properties.max_speed : 6;
-    return Math.min(maxSpeed, Math.max(1, Math.round(value)));
+    return Math.min(maxSpeed, Math.max(0, Math.round(value)));
   }
 
   private normalizePercent(value: number) {
-    return Math.min(100, Math.max(1, Math.round(value)));
+    return Math.min(100, Math.max(0, Math.round(value)));
   }
 
   private shadePositionForOpen(device: SimulatorDevice, open: number) {
@@ -950,6 +964,8 @@ export class BondSimulatorServer {
         ...this.getDevice(device.id),
         properties: device.properties,
         state: this.getState(device.id),
+        lastUpdatedAt: device.lastUpdatedAt ?? 0,
+        lastUpdatedBy: device.lastUpdatedBy ?? null,
       })),
       homebridgeConfig: {
         platform: 'Bond',
@@ -968,6 +984,16 @@ export class BondSimulatorServer {
   private displayAddress() {
     const host = this.httpHost === '0.0.0.0' ? '127.0.0.1' : this.httpHost;
     return `${host}:${this.httpPort}`;
+  }
+
+  private markDeviceUpdated(deviceId: string, updatedBy: 'external' | 'ui') {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device) {
+      return;
+    }
+
+    device.lastUpdatedAt = Date.now();
+    device.lastUpdatedBy = updatedBy;
   }
 
   private hash() {

--- a/tools/bond-simulator/server.ts
+++ b/tools/bond-simulator/server.ts
@@ -25,6 +25,7 @@ export const SIM_POSITION_SHADE_ID = '00000202';
 export const SIM_AWNING_SHADE_ID = '00000203';
 export const SIM_BASIC_FIREPLACE_ID = '00000301';
 export const SIM_FLAME_FIREPLACE_ID = '00000302';
+export const SIM_GENERIC_ID = '00000401';
 
 type JsonObject = Record<string, unknown>;
 
@@ -71,10 +72,13 @@ interface SimulatorDevice {
     open?: number;
     position?: number;
     flame?: number;
+    active_hold?: string;
   };
   lastUpdatedAt?: number;
   lastUpdatedBy?: 'external' | 'ui';
 }
+
+type SimulatorNumericStateKey = Exclude<keyof SimulatorDevice['state'], 'active_hold'>;
 
 const NOOP_BROADCASTER: BpupBroadcaster = {
   broadcast: () => undefined,
@@ -308,7 +312,6 @@ export class BondSimulatorServer {
           power: 0,
           speed: 1,
           light: 0,
-          brightness: 50,
         },
       },
       {
@@ -378,6 +381,19 @@ export class BondSimulatorServer {
         state: {
           power: 0,
           flame: 50,
+        },
+      },
+      {
+        id: SIM_GENERIC_ID,
+        name: 'Generic Toggle',
+        location: DEFAULT_DEVICE_LOCATION,
+        type: 'GX',
+        actions: ['TogglePower'],
+        properties: {
+          trust_state: true,
+        },
+        state: {
+          power: 0,
         },
       },
     ];
@@ -680,7 +696,7 @@ export class BondSimulatorServer {
     }
 
     if (this.isHoldAction(actionName)) {
-      return true;
+      return this.setHoldAction(deviceId, actionName);
     }
 
     return false;
@@ -824,6 +840,26 @@ export class BondSimulatorServer {
     return true;
   }
 
+  private setHoldAction(deviceId: string, actionName: string) {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device) {
+      return false;
+    }
+
+    if (actionName === 'Stop') {
+      if (device.state.active_hold === undefined) {
+        return true;
+      }
+      delete device.state.active_hold;
+      this.broadcastState(device.id);
+      return true;
+    }
+
+    device.state.active_hold = actionName;
+    this.broadcastState(device.id);
+    return true;
+  }
+
   private setFlame(deviceId: string, value: number) {
     const device = this.getSimulatorDevice(deviceId);
     if (!device || device.state.flame === undefined) {
@@ -868,7 +904,7 @@ export class BondSimulatorServer {
     return false;
   }
 
-  private setStateNumber(device: SimulatorDevice, key: keyof SimulatorDevice['state'], value: number) {
+  private setStateNumber(device: SimulatorDevice, key: SimulatorNumericStateKey, value: number) {
     if (device.state[key] === value) {
       return false;
     }

--- a/tools/bond-simulator/server.ts
+++ b/tools/bond-simulator/server.ts
@@ -11,6 +11,14 @@ export const SIM_LIGHT_ID = '00000001';
 export const SIM_DIMMABLE_LIGHT_ID = '00000002';
 export const SIM_SET_BRIGHTNESS_ONLY_LIGHT_ID = '00000003';
 export const SIM_TURN_LIGHT_OFF_ONLY_LIGHT_ID = '00000004';
+export const SIM_BASIC_FAN_ID = '00000101';
+export const SIM_DIRECTION_FAN_ID = '00000102';
+export const SIM_SPEED_BUTTON_FAN_ID = '00000103';
+export const SIM_LIGHT_FAN_ID = '00000104';
+export const SIM_UP_DOWN_LIGHT_FAN_ID = '00000105';
+export const SIM_DIMMER_FAN_ID = '00000106';
+export const SIM_UP_DOWN_DIMMER_FAN_ID = '00000107';
+export const SIM_BRIGHTNESS_BUTTON_FAN_ID = '00000108';
 
 type JsonObject = Record<string, unknown>;
 
@@ -40,11 +48,16 @@ interface SimulatorDevice {
   actions: string[];
   properties: {
     trust_state: boolean;
-    max_speed: null;
+    max_speed?: number | null;
   };
   state: {
-    light: number;
+    light?: number;
     brightness?: number;
+    power?: number;
+    speed?: number;
+    direction?: number;
+    up_light?: number;
+    down_light?: number;
   };
 }
 
@@ -130,6 +143,154 @@ export class BondSimulatorServer {
         },
         state: {
           light: 0,
+        },
+      },
+      {
+        id: SIM_BASIC_FAN_ID,
+        name: 'Basic Fan',
+        location: 'Simulator',
+        type: 'CF',
+        actions: ['TurnOn', 'TurnOff', 'SetSpeed'],
+        properties: {
+          trust_state: true,
+          max_speed: 3,
+        },
+        state: {
+          power: 0,
+          speed: 1,
+        },
+      },
+      {
+        id: SIM_DIRECTION_FAN_ID,
+        name: 'Direction Fan',
+        location: 'Simulator',
+        type: 'CF',
+        actions: ['TurnOn', 'TurnOff', 'SetSpeed', 'ToggleDirection'],
+        properties: {
+          trust_state: true,
+          max_speed: 3,
+        },
+        state: {
+          power: 0,
+          speed: 1,
+          direction: 1,
+        },
+      },
+      {
+        id: SIM_SPEED_BUTTON_FAN_ID,
+        name: 'Speed Button Fan',
+        location: 'Simulator',
+        type: 'CF',
+        actions: ['TurnOn', 'TurnOff', 'IncreaseSpeed', 'DecreaseSpeed'],
+        properties: {
+          trust_state: true,
+        },
+        state: {
+          power: 0,
+          speed: 1,
+        },
+      },
+      {
+        id: SIM_LIGHT_FAN_ID,
+        name: 'Fan With Light',
+        location: 'Simulator',
+        type: 'CF',
+        actions: ['TurnOn', 'TurnOff', 'SetSpeed', 'ToggleLight'],
+        properties: {
+          trust_state: true,
+          max_speed: 3,
+        },
+        state: {
+          power: 0,
+          speed: 1,
+          light: 0,
+        },
+      },
+      {
+        id: SIM_UP_DOWN_LIGHT_FAN_ID,
+        name: 'Fan With Up Down Lights',
+        location: 'Simulator',
+        type: 'CF',
+        actions: ['TurnOn', 'TurnOff', 'SetSpeed', 'ToggleUpLight', 'ToggleDownLight'],
+        properties: {
+          trust_state: true,
+          max_speed: 3,
+        },
+        state: {
+          power: 0,
+          speed: 1,
+          light: 1,
+          up_light: 0,
+          down_light: 0,
+        },
+      },
+      {
+        id: SIM_DIMMER_FAN_ID,
+        name: 'Fan Light Dimmer',
+        location: 'Simulator',
+        type: 'CF',
+        actions: ['TurnOn', 'TurnOff', 'SetSpeed', 'ToggleLight', 'StartDimmer', 'Stop'],
+        properties: {
+          trust_state: true,
+          max_speed: 3,
+        },
+        state: {
+          power: 0,
+          speed: 1,
+          light: 0,
+        },
+      },
+      {
+        id: SIM_UP_DOWN_DIMMER_FAN_ID,
+        name: 'Fan Up Down Dimmer',
+        location: 'Simulator',
+        type: 'CF',
+        actions: [
+          'TurnOn',
+          'TurnOff',
+          'SetSpeed',
+          'ToggleUpLight',
+          'ToggleDownLight',
+          'StartDimmer',
+          'StartUpLightDimmer',
+          'StartDownLightDimmer',
+          'Stop',
+        ],
+        properties: {
+          trust_state: true,
+          max_speed: 3,
+        },
+        state: {
+          power: 0,
+          speed: 1,
+          light: 1,
+          up_light: 0,
+          down_light: 0,
+        },
+      },
+      {
+        id: SIM_BRIGHTNESS_BUTTON_FAN_ID,
+        name: 'Fan Brightness Buttons',
+        location: 'Simulator',
+        type: 'CF',
+        actions: [
+          'TurnOn',
+          'TurnOff',
+          'SetSpeed',
+          'ToggleLight',
+          'StartIncreasingBrightness',
+          'StartDecreasingBrightness',
+          'Stop',
+        ],
+        properties: {
+          trust_state: true,
+          max_speed: 3,
+        },
+        state: {
+          power: 0,
+          speed: 1,
+          light: 0,
+          brightness: 50,
         },
       },
     ];
@@ -250,6 +411,20 @@ export class BondSimulatorServer {
       return;
     }
 
+    if (request.method === 'PUT' && pathname === '/simulator/action') {
+      const body = await this.readJsonBody(request);
+      const id = typeof body.id === 'string' ? body.id : undefined;
+      const action = typeof body.action === 'string' ? body.action : undefined;
+      if (!id || !action) {
+        this.sendJson(response, 400, { error: 'missing_action' });
+        return;
+      }
+
+      const handled = this.handleAction(id, action, body);
+      this.sendJson(response, handled ? 200 : 404, handled ? this.simulatorStatus() : { error: 'not_found' });
+      return;
+    }
+
     this.sendJson(response, 404, { error: 'not_found' });
   }
 
@@ -347,6 +522,42 @@ export class BondSimulatorServer {
       return this.setLight(deviceId, 0);
     }
 
+    if (actionName === 'TurnOn') {
+      return this.setFanPower(deviceId, 1);
+    }
+
+    if (actionName === 'TurnOff') {
+      return this.setFanPower(deviceId, 0);
+    }
+
+    if (actionName === 'SetSpeed' && typeof body.argument === 'number') {
+      return this.setFanSpeed(deviceId, body.argument);
+    }
+
+    if (actionName === 'IncreaseSpeed') {
+      return this.stepFanSpeed(deviceId, 1);
+    }
+
+    if (actionName === 'DecreaseSpeed') {
+      return this.stepFanSpeed(deviceId, -1);
+    }
+
+    if (actionName === 'ToggleDirection') {
+      return this.toggleDirection(deviceId);
+    }
+
+    if (actionName === 'ToggleUpLight') {
+      return this.toggleLightField(deviceId, 'up_light');
+    }
+
+    if (actionName === 'ToggleDownLight') {
+      return this.toggleLightField(deviceId, 'down_light');
+    }
+
+    if (this.isHoldAction(actionName)) {
+      return true;
+    }
+
     return false;
   }
 
@@ -356,21 +567,9 @@ export class BondSimulatorServer {
       return false;
     }
 
-    let changed = false;
-    if ((body.light === 0 || body.light === 1) && device.state.light !== body.light) {
-      device.state.light = body.light;
-      changed = true;
-    }
-
-    if (typeof body.brightness === 'number' && device.state.brightness !== undefined) {
-      const brightness = this.normalizeBrightness(body.brightness);
-      if (device.state.brightness !== brightness) {
-        device.state.brightness = brightness;
-        changed = true;
-      }
-    }
-
-    return changed;
+    return Object.entries(body).reduce((changed, [key, value]) => (
+      this.patchStateField(device, key, value) || changed
+    ), false);
   }
 
   private toggleLight(deviceId: string) {
@@ -384,7 +583,7 @@ export class BondSimulatorServer {
 
   private setLight(deviceId: string, value: number) {
     const device = this.getSimulatorDevice(deviceId);
-    if (!device) {
+    if (!device || device.state.light === undefined) {
       return false;
     }
 
@@ -405,6 +604,96 @@ export class BondSimulatorServer {
     return true;
   }
 
+  private setFanPower(deviceId: string, value: number) {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device || device.state.power === undefined) {
+      return false;
+    }
+
+    device.state.power = value;
+    this.broadcastState(device.id);
+    return true;
+  }
+
+  private setFanSpeed(deviceId: string, value: number) {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device || device.state.speed === undefined) {
+      return false;
+    }
+
+    device.state.speed = this.normalizeSpeed(device, value);
+    if (device.state.power !== undefined) {
+      device.state.power = 1;
+    }
+    this.broadcastState(device.id);
+    return true;
+  }
+
+  private stepFanSpeed(deviceId: string, direction: number) {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device || device.state.speed === undefined) {
+      return false;
+    }
+
+    return this.setFanSpeed(deviceId, device.state.speed + direction);
+  }
+
+  private toggleDirection(deviceId: string) {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device || device.state.direction === undefined) {
+      return false;
+    }
+
+    device.state.direction = device.state.direction === 1 ? -1 : 1;
+    this.broadcastState(device.id);
+    return true;
+  }
+
+  private toggleLightField(deviceId: string, field: 'up_light' | 'down_light') {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device || device.state[field] === undefined) {
+      return false;
+    }
+
+    device.state.light = 1;
+    device.state[field] = device.state[field] === 1 ? 0 : 1;
+    this.broadcastState(device.id);
+    return true;
+  }
+
+  private patchStateField(device: SimulatorDevice, key: string, value: unknown) {
+    if (key === 'brightness' && typeof value === 'number' && device.state.brightness !== undefined) {
+      return this.setStateNumber(device, key, this.normalizeBrightness(value));
+    }
+
+    if (key === 'speed' && typeof value === 'number' && device.state.speed !== undefined) {
+      return this.setStateNumber(device, key, this.normalizeSpeed(device, value));
+    }
+
+    if (
+      (key === 'light' || key === 'power' || key === 'up_light' || key === 'down_light')
+      && (value === 0 || value === 1)
+      && device.state[key] !== undefined
+    ) {
+      return this.setStateNumber(device, key, value);
+    }
+
+    if (key === 'direction' && (value === 1 || value === -1) && device.state.direction !== undefined) {
+      return this.setStateNumber(device, key, value);
+    }
+
+    return false;
+  }
+
+  private setStateNumber(device: SimulatorDevice, key: keyof SimulatorDevice['state'], value: number) {
+    if (device.state[key] === value) {
+      return false;
+    }
+
+    device.state[key] = value;
+    return true;
+  }
+
   private broadcastState(deviceId: string) {
     this.broadcaster.broadcast({
       B: this.bondId,
@@ -420,6 +709,22 @@ export class BondSimulatorServer {
 
   private normalizeBrightness(value: number) {
     return Math.min(100, Math.max(1, Math.round(value)));
+  }
+
+  private normalizeSpeed(device: SimulatorDevice, value: number) {
+    const maxSpeed = typeof device.properties.max_speed === 'number' ? device.properties.max_speed : 6;
+    return Math.min(maxSpeed, Math.max(1, Math.round(value)));
+  }
+
+  private isHoldAction(actionName: string) {
+    return [
+      'StartDimmer',
+      'StartUpLightDimmer',
+      'StartDownLightDimmer',
+      'StartIncreasingBrightness',
+      'StartDecreasingBrightness',
+      'Stop',
+    ].includes(actionName);
   }
 
   private versionBody() {
@@ -445,6 +750,8 @@ export class BondSimulatorServer {
       })),
       homebridgeConfig: {
         platform: 'Bond',
+        include_dimmer: true,
+        include_toggle_state: true,
         bonds: [
           {
             ip_address: this.displayAddress(),

--- a/tools/bond-simulator/server.ts
+++ b/tools/bond-simulator/server.ts
@@ -7,6 +7,7 @@ export const DEFAULT_HTTP_PORT = 18080;
 export const DEFAULT_BPUP_PORT = 30007;
 export const DEFAULT_TOKEN = 'sim-token';
 export const DEFAULT_BOND_ID = 'SIMBOND000001';
+export const DEFAULT_DEVICE_LOCATION = '';
 export const SIM_LIGHT_ID = '00000001';
 export const SIM_DIMMABLE_LIGHT_ID = '00000002';
 export const SIM_SET_BRIGHTNESS_ONLY_LIGHT_ID = '00000003';
@@ -99,7 +100,7 @@ export class BondSimulatorServer {
       {
         id: SIM_LIGHT_ID,
         name: 'Toggle Light',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'LT',
         actions: ['ToggleLight'],
         properties: {
@@ -113,7 +114,7 @@ export class BondSimulatorServer {
       {
         id: SIM_DIMMABLE_LIGHT_ID,
         name: 'Dimmable Light',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'LT',
         actions: ['ToggleLight', 'SetBrightness', 'TurnLightOff'],
         properties: {
@@ -128,7 +129,7 @@ export class BondSimulatorServer {
       {
         id: SIM_SET_BRIGHTNESS_ONLY_LIGHT_ID,
         name: 'Set Brightness Only Light',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'LT',
         actions: ['ToggleLight', 'SetBrightness'],
         properties: {
@@ -143,7 +144,7 @@ export class BondSimulatorServer {
       {
         id: SIM_TURN_LIGHT_OFF_ONLY_LIGHT_ID,
         name: 'Turn Light Off Only Light',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'LT',
         actions: ['ToggleLight', 'TurnLightOff'],
         properties: {
@@ -157,7 +158,7 @@ export class BondSimulatorServer {
       {
         id: SIM_BASIC_FAN_ID,
         name: 'Basic Fan',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'CF',
         actions: ['TurnOn', 'TurnOff', 'SetSpeed'],
         properties: {
@@ -172,7 +173,7 @@ export class BondSimulatorServer {
       {
         id: SIM_DIRECTION_FAN_ID,
         name: 'Direction Fan',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'CF',
         actions: ['TurnOn', 'TurnOff', 'SetSpeed', 'ToggleDirection'],
         properties: {
@@ -188,7 +189,7 @@ export class BondSimulatorServer {
       {
         id: SIM_SPEED_BUTTON_FAN_ID,
         name: 'Speed Button Fan',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'CF',
         actions: ['TurnOn', 'TurnOff', 'IncreaseSpeed', 'DecreaseSpeed'],
         properties: {
@@ -202,7 +203,7 @@ export class BondSimulatorServer {
       {
         id: SIM_LIGHT_FAN_ID,
         name: 'Fan With Light',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'CF',
         actions: ['TurnOn', 'TurnOff', 'SetSpeed', 'ToggleLight'],
         properties: {
@@ -218,7 +219,7 @@ export class BondSimulatorServer {
       {
         id: SIM_UP_DOWN_LIGHT_FAN_ID,
         name: 'Fan With Up Down Lights',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'CF',
         actions: ['TurnOn', 'TurnOff', 'SetSpeed', 'ToggleUpLight', 'ToggleDownLight'],
         properties: {
@@ -236,7 +237,7 @@ export class BondSimulatorServer {
       {
         id: SIM_DIMMER_FAN_ID,
         name: 'Fan Light Dimmer',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'CF',
         actions: ['TurnOn', 'TurnOff', 'SetSpeed', 'ToggleLight', 'StartDimmer', 'Stop'],
         properties: {
@@ -252,7 +253,7 @@ export class BondSimulatorServer {
       {
         id: SIM_UP_DOWN_DIMMER_FAN_ID,
         name: 'Fan Up Down Dimmer',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'CF',
         actions: [
           'TurnOn',
@@ -280,7 +281,7 @@ export class BondSimulatorServer {
       {
         id: SIM_BRIGHTNESS_BUTTON_FAN_ID,
         name: 'Fan Brightness Buttons',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'CF',
         actions: [
           'TurnOn',
@@ -305,7 +306,7 @@ export class BondSimulatorServer {
       {
         id: SIM_TOGGLE_SHADE_ID,
         name: 'Toggle Shade',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'MS',
         actions: ['ToggleOpen'],
         properties: {
@@ -318,7 +319,7 @@ export class BondSimulatorServer {
       {
         id: SIM_POSITION_SHADE_ID,
         name: 'Position Shade',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'MS',
         actions: ['ToggleOpen', 'SetPosition'],
         properties: {
@@ -332,7 +333,7 @@ export class BondSimulatorServer {
       {
         id: SIM_AWNING_SHADE_ID,
         name: 'Awning Shade With Preset',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'MS',
         subtype: 'AWNING',
         actions: ['ToggleOpen', 'SetPosition', 'Preset'],
@@ -347,7 +348,7 @@ export class BondSimulatorServer {
       {
         id: SIM_BASIC_FIREPLACE_ID,
         name: 'Basic Fireplace',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'FP',
         actions: ['TogglePower'],
         properties: {
@@ -360,7 +361,7 @@ export class BondSimulatorServer {
       {
         id: SIM_FLAME_FIREPLACE_ID,
         name: 'Flame Fireplace',
-        location: 'Simulator',
+        location: DEFAULT_DEVICE_LOCATION,
         type: 'FP',
         actions: ['TogglePower', 'SetFlame'],
         properties: {

--- a/tools/bond-simulator/server.ts
+++ b/tools/bond-simulator/server.ts
@@ -19,6 +19,9 @@ export const SIM_UP_DOWN_LIGHT_FAN_ID = '00000105';
 export const SIM_DIMMER_FAN_ID = '00000106';
 export const SIM_UP_DOWN_DIMMER_FAN_ID = '00000107';
 export const SIM_BRIGHTNESS_BUTTON_FAN_ID = '00000108';
+export const SIM_TOGGLE_SHADE_ID = '00000201';
+export const SIM_POSITION_SHADE_ID = '00000202';
+export const SIM_AWNING_SHADE_ID = '00000203';
 
 type JsonObject = Record<string, unknown>;
 
@@ -45,6 +48,7 @@ interface SimulatorDevice {
   name: string;
   location: string;
   type: string;
+  subtype?: string;
   actions: string[];
   properties: {
     trust_state: boolean;
@@ -58,6 +62,8 @@ interface SimulatorDevice {
     direction?: number;
     up_light?: number;
     down_light?: number;
+    open?: number;
+    position?: number;
   };
 }
 
@@ -293,6 +299,48 @@ export class BondSimulatorServer {
           brightness: 50,
         },
       },
+      {
+        id: SIM_TOGGLE_SHADE_ID,
+        name: 'Toggle Shade',
+        location: 'Simulator',
+        type: 'MS',
+        actions: ['ToggleOpen'],
+        properties: {
+          trust_state: true,
+        },
+        state: {
+          open: 0,
+        },
+      },
+      {
+        id: SIM_POSITION_SHADE_ID,
+        name: 'Position Shade',
+        location: 'Simulator',
+        type: 'MS',
+        actions: ['ToggleOpen', 'SetPosition'],
+        properties: {
+          trust_state: true,
+        },
+        state: {
+          open: 0,
+          position: 100,
+        },
+      },
+      {
+        id: SIM_AWNING_SHADE_ID,
+        name: 'Awning Shade With Preset',
+        location: 'Simulator',
+        type: 'MS',
+        subtype: 'AWNING',
+        actions: ['ToggleOpen', 'SetPosition', 'Preset'],
+        properties: {
+          trust_state: true,
+        },
+        state: {
+          open: 0,
+          position: 0,
+        },
+      },
     ];
   }
 
@@ -336,6 +384,7 @@ export class BondSimulatorServer {
       name: device.name,
       location: device.location,
       type: device.type,
+      ...(device.subtype ? { subtype: device.subtype } : {}),
       actions: [...device.actions],
       properties: {},
       state: {},
@@ -554,6 +603,18 @@ export class BondSimulatorServer {
       return this.toggleLightField(deviceId, 'down_light');
     }
 
+    if (actionName === 'ToggleOpen') {
+      return this.toggleOpen(deviceId);
+    }
+
+    if (actionName === 'SetPosition' && typeof body.argument === 'number') {
+      return this.setPosition(deviceId, body.argument);
+    }
+
+    if (actionName === 'Preset') {
+      return this.setPosition(deviceId, 50);
+    }
+
     if (this.isHoldAction(actionName)) {
       return true;
     }
@@ -661,6 +722,33 @@ export class BondSimulatorServer {
     return true;
   }
 
+  private toggleOpen(deviceId: string) {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device || device.state.open === undefined) {
+      return false;
+    }
+
+    device.state.open = device.state.open === 1 ? 0 : 1;
+    if (device.state.position !== undefined) {
+      device.state.position = this.shadePositionForOpen(device, device.state.open);
+    }
+    this.broadcastState(device.id);
+    return true;
+  }
+
+  private setPosition(deviceId: string, value: number) {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device || device.state.position === undefined) {
+      return false;
+    }
+
+    const position = this.normalizePosition(value);
+    device.state.position = position;
+    device.state.open = this.shadeOpenForPosition(device, position);
+    this.broadcastState(device.id);
+    return true;
+  }
+
   private patchStateField(device: SimulatorDevice, key: string, value: unknown) {
     if (key === 'brightness' && typeof value === 'number' && device.state.brightness !== undefined) {
       return this.setStateNumber(device, key, this.normalizeBrightness(value));
@@ -670,8 +758,12 @@ export class BondSimulatorServer {
       return this.setStateNumber(device, key, this.normalizeSpeed(device, value));
     }
 
+    if (key === 'position' && typeof value === 'number' && device.state.position !== undefined) {
+      return this.setStateNumber(device, key, this.normalizePosition(value));
+    }
+
     if (
-      (key === 'light' || key === 'power' || key === 'up_light' || key === 'down_light')
+      (key === 'light' || key === 'power' || key === 'up_light' || key === 'down_light' || key === 'open')
       && (value === 0 || value === 1)
       && device.state[key] !== undefined
     ) {
@@ -711,9 +803,29 @@ export class BondSimulatorServer {
     return Math.min(100, Math.max(1, Math.round(value)));
   }
 
+  private normalizePosition(value: number) {
+    return Math.min(100, Math.max(0, Math.round(value)));
+  }
+
   private normalizeSpeed(device: SimulatorDevice, value: number) {
     const maxSpeed = typeof device.properties.max_speed === 'number' ? device.properties.max_speed : 6;
     return Math.min(maxSpeed, Math.max(1, Math.round(value)));
+  }
+
+  private shadePositionForOpen(device: SimulatorDevice, open: number) {
+    if (device.subtype === 'AWNING') {
+      return open === 1 ? 100 : 0;
+    }
+
+    return open === 1 ? 0 : 100;
+  }
+
+  private shadeOpenForPosition(device: SimulatorDevice, position: number) {
+    if (device.subtype === 'AWNING') {
+      return position > 0 ? 1 : 0;
+    }
+
+    return position < 100 ? 1 : 0;
   }
 
   private isHoldAction(actionName: string) {

--- a/tools/bond-simulator/server.ts
+++ b/tools/bond-simulator/server.ts
@@ -8,6 +8,7 @@ export const DEFAULT_BPUP_PORT = 30007;
 export const DEFAULT_TOKEN = 'sim-token';
 export const DEFAULT_BOND_ID = 'SIMBOND000001';
 export const SIM_LIGHT_ID = '00000001';
+export const SIM_DIMMABLE_LIGHT_ID = '00000002';
 
 type JsonObject = Record<string, unknown>;
 
@@ -41,6 +42,7 @@ interface SimulatorDevice {
   };
   state: {
     light: number;
+    brightness?: number;
   };
 }
 
@@ -60,7 +62,7 @@ export class BondSimulatorServer {
   public readonly token: string;
   public readonly staticDir: string;
   private readonly broadcaster: BpupBroadcaster;
-  private readonly device: SimulatorDevice;
+  private readonly devices: SimulatorDevice[];
   private httpHost = '127.0.0.1';
   private httpPort = DEFAULT_HTTP_PORT;
 
@@ -69,20 +71,37 @@ export class BondSimulatorServer {
     this.token = options.token ?? DEFAULT_TOKEN;
     this.staticDir = options.staticDir ?? join(__dirname, 'static');
     this.broadcaster = options.broadcaster ?? NOOP_BROADCASTER;
-    this.device = {
-      id: SIM_LIGHT_ID,
-      name: 'Sim Light',
-      location: 'Simulator',
-      type: 'LT',
-      actions: ['ToggleLight'],
-      properties: {
-        trust_state: true,
-        max_speed: null,
+    this.devices = [
+      {
+        id: SIM_LIGHT_ID,
+        name: 'Sim Light',
+        location: 'Simulator',
+        type: 'LT',
+        actions: ['ToggleLight'],
+        properties: {
+          trust_state: true,
+          max_speed: null,
+        },
+        state: {
+          light: 0,
+        },
       },
-      state: {
-        light: 0,
+      {
+        id: SIM_DIMMABLE_LIGHT_ID,
+        name: 'Dimmer Light',
+        location: 'Simulator',
+        type: 'LT',
+        actions: ['ToggleLight', 'SetBrightness', 'TurnLightOff'],
+        properties: {
+          trust_state: true,
+          max_speed: null,
+        },
+        state: {
+          light: 0,
+          brightness: 50,
+        },
       },
-    };
+    ];
   }
 
   public createHttpServer() {
@@ -111,16 +130,21 @@ export class BondSimulatorServer {
     return server;
   }
 
-  public getState() {
-    return { ...this.device.state };
+  public getState(id = SIM_LIGHT_ID) {
+    return { ...this.getSimulatorDevice(id)?.state };
   }
 
-  public getDevice() {
+  public getDevice(id = SIM_LIGHT_ID) {
+    const device = this.getSimulatorDevice(id);
+    if (!device) {
+      return undefined;
+    }
+
     return {
-      name: this.device.name,
-      location: this.device.location,
-      type: this.device.type,
-      actions: [...this.device.actions],
+      name: device.name,
+      location: device.location,
+      type: device.type,
+      actions: [...device.actions],
       properties: {},
       state: {},
     };
@@ -151,38 +175,17 @@ export class BondSimulatorServer {
     }
 
     if (request.method === 'GET' && pathname === '/v2/devices') {
-      this.sendJson(response, 200, { _: this.hash(), [this.device.id]: { _: this.hash() } });
+      const body: JsonObject = { _: this.hash() };
+      this.devices.forEach(device => {
+        body[device.id] = { _: this.hash() };
+      });
+      this.sendJson(response, 200, body);
       return;
     }
 
-    if (request.method === 'GET' && pathname === `/v2/devices/${this.device.id}`) {
-      this.sendJson(response, 200, this.getDevice());
-      return;
-    }
-
-    if (request.method === 'GET' && pathname === `/v2/devices/${this.device.id}/properties`) {
-      this.sendJson(response, 200, this.device.properties);
-      return;
-    }
-
-    if (request.method === 'GET' && pathname === `/v2/devices/${this.device.id}/state`) {
-      this.sendJson(response, 200, this.device.state);
-      return;
-    }
-
-    if (request.method === 'PATCH' && pathname === `/v2/devices/${this.device.id}/state`) {
-      const body = await this.readJsonBody(request);
-      const changed = this.patchState(body);
-      if (changed) {
-        this.broadcastState();
-      }
-      this.sendJson(response, 200, {});
-      return;
-    }
-
-    if (request.method === 'PUT' && pathname === `/v2/devices/${this.device.id}/actions/ToggleLight`) {
-      this.setLight(this.device.state.light === 1 ? 0 : 1);
-      this.sendJson(response, 200, {});
+    const devicePath = pathname.match(/^\/v2\/devices\/([^/]+)(?:\/([^/]+)(?:\/([^/]+))?)?$/);
+    if (devicePath) {
+      await this.handleDeviceRequest(request, response, devicePath[1], devicePath[2], devicePath[3]);
       return;
     }
 
@@ -197,8 +200,22 @@ export class BondSimulatorServer {
     }
 
     if (request.method === 'PUT' && pathname === '/simulator/toggle') {
-      this.setLight(this.device.state.light === 1 ? 0 : 1);
+      const id = requestUrl.searchParams.get('id') ?? SIM_LIGHT_ID;
+      this.toggleLight(id);
       this.sendJson(response, 200, this.simulatorStatus());
+      return;
+    }
+
+    if (request.method === 'PUT' && pathname === '/simulator/brightness') {
+      const body = await this.readJsonBody(request);
+      const id = typeof body.id === 'string' ? body.id : SIM_DIMMABLE_LIGHT_ID;
+      const brightness = typeof body.brightness === 'number' ? body.brightness : undefined;
+      if (brightness === undefined) {
+        this.sendJson(response, 400, { error: 'missing_brightness' });
+        return;
+      }
+      const handled = this.setBrightness(id, brightness);
+      this.sendJson(response, handled ? 200 : 404, handled ? this.simulatorStatus() : { error: 'not_found' });
       return;
     }
 
@@ -233,28 +250,140 @@ export class BondSimulatorServer {
     this.sendJson(response, 405, { error: 'method_not_allowed' });
   }
 
-  private patchState(body: JsonObject) {
-    const current = this.device.state.light;
-    if (body.light !== 0 && body.light !== 1) {
+  private async handleDeviceRequest(
+    request: IncomingMessage,
+    response: ServerResponse,
+    deviceId: string,
+    child?: string,
+    actionName?: string,
+  ) {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device) {
+      this.sendJson(response, 404, { error: 'not_found' });
+      return;
+    }
+
+    if (request.method === 'GET' && child === undefined) {
+      this.sendJson(response, 200, this.getDevice(device.id));
+      return;
+    }
+
+    if (request.method === 'GET' && child === 'properties') {
+      this.sendJson(response, 200, device.properties);
+      return;
+    }
+
+    if (request.method === 'GET' && child === 'state') {
+      this.sendJson(response, 200, device.state);
+      return;
+    }
+
+    if (request.method === 'PATCH' && child === 'state') {
+      const body = await this.readJsonBody(request);
+      const changed = this.patchState(device.id, body);
+      if (changed) {
+        this.broadcastState(device.id);
+      }
+      this.sendJson(response, 200, {});
+      return;
+    }
+
+    if (request.method === 'PUT' && child === 'actions' && actionName) {
+      const body = await this.readJsonBody(request);
+      const handled = this.handleAction(device.id, actionName, body);
+      this.sendJson(response, handled ? 200 : 404, handled ? {} : { error: 'not_found' });
+      return;
+    }
+
+    this.sendJson(response, 404, { error: 'not_found' });
+  }
+
+  private handleAction(deviceId: string, actionName: string, body: JsonObject) {
+    if (actionName === 'ToggleLight') {
+      return this.toggleLight(deviceId);
+    }
+
+    if (actionName === 'SetBrightness' && typeof body.argument === 'number') {
+      return this.setBrightness(deviceId, body.argument);
+    }
+
+    if (actionName === 'TurnLightOff') {
+      return this.setLight(deviceId, 0);
+    }
+
+    return false;
+  }
+
+  private patchState(deviceId: string, body: JsonObject) {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device) {
       return false;
     }
 
-    this.device.state.light = body.light;
-    return current !== body.light;
+    let changed = false;
+    if ((body.light === 0 || body.light === 1) && device.state.light !== body.light) {
+      device.state.light = body.light;
+      changed = true;
+    }
+
+    if (typeof body.brightness === 'number' && device.state.brightness !== undefined) {
+      const brightness = this.normalizeBrightness(body.brightness);
+      if (device.state.brightness !== brightness) {
+        device.state.brightness = brightness;
+        changed = true;
+      }
+    }
+
+    return changed;
   }
 
-  private setLight(value: number) {
-    this.device.state.light = value;
-    this.broadcastState();
+  private toggleLight(deviceId: string) {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device) {
+      return false;
+    }
+
+    return this.setLight(device.id, device.state.light === 1 ? 0 : 1);
   }
 
-  private broadcastState() {
+  private setLight(deviceId: string, value: number) {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device) {
+      return false;
+    }
+
+    device.state.light = value;
+    this.broadcastState(device.id);
+    return true;
+  }
+
+  private setBrightness(deviceId: string, value: number) {
+    const device = this.getSimulatorDevice(deviceId);
+    if (!device || device.state.brightness === undefined) {
+      return false;
+    }
+
+    device.state.brightness = this.normalizeBrightness(value);
+    device.state.light = 1;
+    this.broadcastState(device.id);
+    return true;
+  }
+
+  private broadcastState(deviceId: string) {
     this.broadcaster.broadcast({
       B: this.bondId,
-      t: `devices/${this.device.id}/state`,
+      t: `devices/${deviceId}/state`,
       m: 4,
-      b: this.getState(),
+      b: this.getState(deviceId),
     });
+  }
+
+  private getSimulatorDevice(id: string) {
+    return this.devices.find(device => device.id === id);
+  }
+
+  private normalizeBrightness(value: number) {
+    return Math.min(100, Math.max(1, Math.round(value)));
   }
 
   private versionBody() {
@@ -272,12 +401,12 @@ export class BondSimulatorServer {
     return {
       version: this.versionBody(),
       token: this.token,
-      device: {
-        id: this.device.id,
-        ...this.getDevice(),
-        properties: this.device.properties,
-        state: this.getState(),
-      },
+      devices: this.devices.map(device => ({
+        id: device.id,
+        ...this.getDevice(device.id),
+        properties: device.properties,
+        state: this.getState(device.id),
+      })),
       homebridgeConfig: {
         platform: 'Bond',
         bonds: [

--- a/tools/bond-simulator/static/app.js
+++ b/tools/bond-simulator/static/app.js
@@ -1,11 +1,10 @@
 const elements = {
   status: document.getElementById('connection-status'),
+  ipAddress: document.getElementById('ip-address'),
   bondId: document.getElementById('bond-id'),
   firmware: document.getElementById('firmware'),
   token: document.getElementById('token'),
   deviceControls: document.getElementById('device-controls'),
-  deviceList: document.getElementById('device-list'),
-  homebridgeConfig: document.getElementById('homebridge-config'),
 };
 const previousExternalUpdates = new Map();
 let hasRendered = false;
@@ -30,6 +29,7 @@ async function request(path, options) {
 function deviceCapabilities(device) {
   return {
     fan: device.type === 'CF',
+    generic: device.type === 'GX',
     shade: device.type === 'MS',
     fireplace: device.type === 'FP',
     speed: device.actions.includes('SetSpeed'),
@@ -37,48 +37,128 @@ function deviceCapabilities(device) {
     direction: device.actions.includes('ToggleDirection'),
     light: device.actions.includes('ToggleLight'),
     upDownLight: device.actions.includes('ToggleUpLight') && device.actions.includes('ToggleDownLight'),
-    brightness: device.actions.includes('SetBrightness') && device.actions.includes('TurnLightOff'),
+    setBrightness: device.actions.includes('SetBrightness'),
+    dimmer: device.actions.includes('StartDimmer') && device.actions.includes('Stop'),
+    upDownDimmer: device.actions.includes('StartUpLightDimmer') && device.actions.includes('StartDownLightDimmer') && device.actions.includes('Stop'),
+    brightnessButtons: device.actions.includes('StartIncreasingBrightness') && device.actions.includes('StartDecreasingBrightness') && device.actions.includes('Stop'),
     position: device.actions.includes('SetPosition'),
     preset: device.actions.includes('Preset'),
     flame: device.actions.includes('SetFlame'),
+    togglePower: device.actions.includes('TogglePower'),
   };
 }
 
-function renderActionButton(device, action, label, pressed = false, extraClass = '') {
+function renderActionButton(device, action, label, extraClass = '') {
   return `
-    <button class="power-button ${extraClass}" data-action="bond-action" data-bond-action="${action}" data-device-id="${device.id}" type="button" aria-pressed="${pressed}">
+    <button class="action-button ${extraClass}" data-action="bond-action" data-bond-action="${action}" data-device-id="${device.id}" type="button">
       <span>${label}</span>
     </button>
   `;
 }
 
-function renderLightControls(device, capabilities) {
-  const lightOn = device.state.light === 1;
+function renderToggleControl(device, action, label, checked, stateLabel = checked ? 'On' : 'Off') {
+  return `
+    <button class="toggle-control" data-action="bond-action" data-bond-action="${action}" data-device-id="${device.id}" type="button" aria-pressed="${checked}">
+      <span class="toggle-label">${label}</span>
+      <span class="toggle-switch" aria-hidden="true"></span>
+      <span class="toggle-state">${stateLabel}</span>
+    </button>
+  `;
+}
+
+function renderControlSection(title, controls) {
+  if (!controls.trim()) {
+    return '';
+  }
+
+  return `
+    <section class="component-section">
+      <h3>${title}</h3>
+      <div class="control-stack">
+        ${controls}
+      </div>
+    </section>
+  `;
+}
+
+function devicePowerState(device, capabilities) {
+  if (capabilities.shade) {
+    return device.state.open === 1;
+  }
+  if (capabilities.light && !capabilities.fan) {
+    return device.state.light === 1;
+  }
+  return device.state.power === 1;
+}
+
+function renderBrightnessSlider(device) {
   const brightness = device.state.brightness ?? 0;
 
-  if (capabilities.upDownLight) {
-    return `
-      <div class="button-row">
-        ${renderActionButton(device, 'ToggleUpLight', device.state.up_light === 1 ? 'Up Light Off' : 'Up Light On', device.state.up_light === 1)}
-        ${renderActionButton(device, 'ToggleDownLight', device.state.down_light === 1 ? 'Down Light Off' : 'Down Light On', device.state.down_light === 1)}
-      </div>
-    `;
-  }
+  return `
+    <label class="slider-control">
+      <span>Brightness</span>
+      <strong>${brightness}%</strong>
+      <input data-action="brightness" data-device-id="${device.id}" type="range" min="0" max="100" value="${brightness}">
+    </label>
+  `;
+}
+
+function renderSingleLightSection(device, capabilities, title = 'Light') {
+  const lightOn = device.state.light === 1;
 
   if (!capabilities.light) {
     return '';
   }
 
-  return `
-    ${renderActionButton(device, 'ToggleLight', lightOn ? 'Light Off' : 'Light On', lightOn)}
-    ${capabilities.brightness ? `
-      <label class="slider-control">
-        <span>Brightness</span>
-        <strong>${brightness}%</strong>
-        <input data-action="brightness" data-device-id="${device.id}" type="range" min="0" max="100" value="${brightness}">
-      </label>
+  const controls = `
+    ${renderToggleControl(device, 'ToggleLight', 'Light', lightOn)}
+    ${capabilities.setBrightness ? renderBrightnessSlider(device) : ''}
+    ${capabilities.dimmer ? `
+      <div class="button-row">
+        ${renderActionButton(device, 'StartDimmer', 'Start Dimmer', 'secondary-button')}
+        ${renderActionButton(device, 'Stop', 'Stop Dimmer', 'secondary-button')}
+      </div>
+    ` : ''}
+    ${capabilities.brightnessButtons ? `
+      <div class="button-row">
+        ${renderActionButton(device, 'StartIncreasingBrightness', 'Brighten', 'secondary-button')}
+        ${renderActionButton(device, 'StartDecreasingBrightness', 'Dim', 'secondary-button')}
+      </div>
+      ${renderActionButton(device, 'Stop', 'Stop Brightness', 'secondary-button')}
     ` : ''}
   `;
+
+  return renderControlSection(title, controls);
+}
+
+function renderSplitLightSections(device, capabilities) {
+  if (!capabilities.upDownLight) {
+    return renderSingleLightSection(device, capabilities);
+  }
+
+  const upLightControls = `
+    ${renderToggleControl(device, 'ToggleUpLight', 'Power', device.state.up_light === 1)}
+    ${capabilities.upDownDimmer ? `
+      <div class="button-row">
+        ${renderActionButton(device, 'StartUpLightDimmer', 'Start Dimmer', 'secondary-button')}
+        ${renderActionButton(device, 'Stop', 'Stop Dimmer', 'secondary-button')}
+      </div>
+    ` : ''}
+  `;
+  const downLightControls = `
+    ${renderToggleControl(device, 'ToggleDownLight', 'Power', device.state.down_light === 1)}
+    ${capabilities.upDownDimmer ? `
+      <div class="button-row">
+        ${renderActionButton(device, 'StartDownLightDimmer', 'Start Dimmer', 'secondary-button')}
+        ${renderActionButton(device, 'Stop', 'Stop Dimmer', 'secondary-button')}
+      </div>
+    ` : ''}
+  `;
+
+  return [
+    renderControlSection('Up Light', upLightControls),
+    renderControlSection('Down Light', downLightControls),
+  ].join('');
 }
 
 function renderFanControls(device, capabilities) {
@@ -86,8 +166,8 @@ function renderFanControls(device, capabilities) {
   const speed = device.state.speed ?? 1;
   const maxSpeed = device.properties.max_speed ?? 6;
 
-  return `
-    ${renderActionButton(device, powerOn ? 'TurnOff' : 'TurnOn', powerOn ? 'Turn Off' : 'Turn On', powerOn)}
+  const fanControls = `
+    ${renderToggleControl(device, powerOn ? 'TurnOff' : 'TurnOn', 'Power', powerOn)}
     ${capabilities.speed ? `
       <label class="slider-control">
         <span>Speed</span>
@@ -97,21 +177,25 @@ function renderFanControls(device, capabilities) {
     ` : ''}
     ${capabilities.speedButtons ? `
       <div class="button-row">
-        ${renderActionButton(device, 'DecreaseSpeed', 'Speed Down', false, 'secondary-button')}
-        ${renderActionButton(device, 'IncreaseSpeed', 'Speed Up', false, 'secondary-button')}
+        ${renderActionButton(device, 'DecreaseSpeed', 'Speed Down', 'secondary-button')}
+        ${renderActionButton(device, 'IncreaseSpeed', 'Speed Up', 'secondary-button')}
       </div>
     ` : ''}
-    ${capabilities.direction ? renderActionButton(device, 'ToggleDirection', device.state.direction === 1 ? 'Reverse' : 'Forward', false, 'secondary-button') : ''}
-    ${renderLightControls(device, capabilities)}
+    ${capabilities.direction ? renderToggleControl(device, 'ToggleDirection', 'Direction', device.state.direction === -1, device.state.direction === 1 ? 'Forward' : 'Reverse') : ''}
   `;
+
+  return [
+    renderControlSection('Fan', fanControls),
+    renderSplitLightSections(device, capabilities),
+  ].join('');
 }
 
 function renderShadeControls(device, capabilities) {
   const open = device.state.open === 1;
   const position = device.state.position ?? (open ? 0 : 100);
 
-  return `
-    ${renderActionButton(device, 'ToggleOpen', open ? 'Close' : 'Open', open)}
+  return renderControlSection('Shade', `
+    ${renderToggleControl(device, 'ToggleOpen', 'Open', open, open ? 'Open' : 'Closed')}
     ${capabilities.position ? `
       <label class="slider-control">
         <span>Position</span>
@@ -119,16 +203,16 @@ function renderShadeControls(device, capabilities) {
         <input data-action="position" data-device-id="${device.id}" type="range" min="0" max="100" value="${position}">
       </label>
     ` : ''}
-    ${capabilities.preset ? renderActionButton(device, 'Preset', 'Preset', false, 'secondary-button') : ''}
-  `;
+    ${capabilities.preset ? renderActionButton(device, 'Preset', 'Preset', 'secondary-button') : ''}
+  `);
 }
 
 function renderFireplaceControls(device, capabilities) {
   const powerOn = device.state.power === 1;
   const flame = device.state.flame ?? 0;
 
-  return `
-    ${renderActionButton(device, 'TogglePower', powerOn ? 'Turn Off' : 'Turn On', powerOn)}
+  return renderControlSection('Fireplace', `
+    ${renderToggleControl(device, 'TogglePower', 'Power', powerOn)}
     ${capabilities.flame ? `
       <label class="slider-control">
         <span>Flame</span>
@@ -136,7 +220,13 @@ function renderFireplaceControls(device, capabilities) {
         <input data-action="flame" data-device-id="${device.id}" type="range" min="0" max="100" value="${flame}">
       </label>
     ` : ''}
-  `;
+  `);
+}
+
+function renderGenericControls(device) {
+  const powerOn = device.state.power === 1;
+
+  return renderControlSection('Power', renderToggleControl(device, 'TogglePower', 'Power', powerOn));
 }
 
 function deviceTypeLabel(type) {
@@ -145,6 +235,7 @@ function deviceTypeLabel(type) {
     CF: 'Fans',
     MS: 'Shades',
     FP: 'Fireplaces',
+    GX: 'Generic',
   }[type] ?? 'Other';
 }
 
@@ -158,15 +249,20 @@ function renderDeviceState(device) {
 
 function renderDeviceControl(device, highlight) {
   const capabilities = deviceCapabilities(device);
+  const isOn = devicePowerState(device, capabilities);
   const controls = capabilities.shade
     ? renderShadeControls(device, capabilities)
     : capabilities.fireplace ? renderFireplaceControls(device, capabilities)
-    : capabilities.fan ? renderFanControls(device, capabilities) : renderLightControls(device, capabilities);
+    : capabilities.fan ? renderFanControls(device, capabilities)
+    : capabilities.generic ? renderGenericControls(device) : renderSingleLightSection(device, capabilities);
 
   return `
-    <article class="panel control-panel ${highlight ? 'external-update' : ''}" data-device-id="${device.id}">
+    <article class="panel control-panel ${isOn ? 'is-on' : 'is-off'} ${highlight ? 'external-update' : ''}" data-device-id="${device.id}">
       <div class="device-heading">
-        <h2>${device.name}</h2>
+        <div class="device-title-row">
+          <h2>${device.name}</h2>
+          ${highlight ? '<span class="update-badge">Updated</span>' : ''}
+        </div>
         <p class="device-meta">${device.id} · ${device.type}${device.subtype ? ` · ${device.subtype}` : ''}</p>
         ${renderDeviceState(device)}
       </div>
@@ -186,21 +282,6 @@ function renderDeviceGroup(type, devices, highlights) {
         ${devices.map(device => renderDeviceControl(device, highlights.has(device.id))).join('')}
       </div>
     </section>
-  `;
-}
-
-function renderDeviceSummary(device) {
-  const actions = device.actions.join(', ');
-  const state = Object.entries(device.state)
-    .map(([key, value]) => `${key}: ${value}`)
-    .join(', ');
-
-  return `
-    <div class="device-summary">
-      <strong>${device.name}</strong>
-      <span>${device.id} · ${actions}</span>
-      <span>${state}</span>
-    </div>
   `;
 }
 
@@ -225,10 +306,11 @@ function render(status) {
 
     return acc;
   }, new Map());
-  const typeOrder = ['LT', 'CF', 'MS', 'FP'];
+  const typeOrder = ['LT', 'CF', 'MS', 'FP', 'GX'];
 
   elements.status.textContent = 'Online';
   elements.status.className = 'status online';
+  elements.ipAddress.textContent = status.homebridgeConfig.bonds[0].ip_address;
   elements.bondId.textContent = status.version.bondid;
   elements.firmware.textContent = status.version.fw_ver;
   elements.token.textContent = status.token;
@@ -236,8 +318,6 @@ function render(status) {
     .filter(type => grouped.has(type))
     .map(type => renderDeviceGroup(type, grouped.get(type), highlights))
     .join('');
-  elements.deviceList.innerHTML = status.devices.map(renderDeviceSummary).join('');
-  elements.homebridgeConfig.textContent = JSON.stringify(status.homebridgeConfig, null, 2);
   hasRendered = true;
 }
 

--- a/tools/bond-simulator/static/app.js
+++ b/tools/bond-simulator/static/app.js
@@ -18,14 +18,81 @@ async function request(path, options) {
 
 function deviceCapabilities(device) {
   return {
+    fan: device.type === 'CF',
+    speed: device.actions.includes('SetSpeed'),
+    speedButtons: device.actions.includes('IncreaseSpeed') && device.actions.includes('DecreaseSpeed'),
+    direction: device.actions.includes('ToggleDirection'),
+    light: device.actions.includes('ToggleLight'),
+    upDownLight: device.actions.includes('ToggleUpLight') && device.actions.includes('ToggleDownLight'),
     brightness: device.actions.includes('SetBrightness') && device.actions.includes('TurnLightOff'),
   };
 }
 
-function renderDeviceControl(device) {
+function renderActionButton(device, action, label, pressed = false, extraClass = '') {
+  return `
+    <button class="power-button ${extraClass}" data-action="bond-action" data-bond-action="${action}" data-device-id="${device.id}" type="button" aria-pressed="${pressed}">
+      <span>${label}</span>
+    </button>
+  `;
+}
+
+function renderLightControls(device, capabilities) {
   const lightOn = device.state.light === 1;
-  const capabilities = deviceCapabilities(device);
   const brightness = device.state.brightness ?? 0;
+
+  if (capabilities.upDownLight) {
+    return `
+      <div class="button-row">
+        ${renderActionButton(device, 'ToggleUpLight', device.state.up_light === 1 ? 'Up Light Off' : 'Up Light On', device.state.up_light === 1)}
+        ${renderActionButton(device, 'ToggleDownLight', device.state.down_light === 1 ? 'Down Light Off' : 'Down Light On', device.state.down_light === 1)}
+      </div>
+    `;
+  }
+
+  if (!capabilities.light) {
+    return '';
+  }
+
+  return `
+    ${renderActionButton(device, 'ToggleLight', lightOn ? 'Light Off' : 'Light On', lightOn)}
+    ${capabilities.brightness ? `
+      <label class="slider-control">
+        <span>Brightness</span>
+        <strong>${brightness}%</strong>
+        <input data-action="brightness" data-device-id="${device.id}" type="range" min="1" max="100" value="${brightness}">
+      </label>
+    ` : ''}
+  `;
+}
+
+function renderFanControls(device, capabilities) {
+  const powerOn = device.state.power === 1;
+  const speed = device.state.speed ?? 1;
+  const maxSpeed = device.properties.max_speed ?? 6;
+
+  return `
+    ${renderActionButton(device, powerOn ? 'TurnOff' : 'TurnOn', powerOn ? 'Turn Off' : 'Turn On', powerOn)}
+    ${capabilities.speed ? `
+      <label class="slider-control">
+        <span>Speed</span>
+        <strong>${speed} / ${maxSpeed}</strong>
+        <input data-action="speed" data-device-id="${device.id}" type="range" min="1" max="${maxSpeed}" value="${speed}">
+      </label>
+    ` : ''}
+    ${capabilities.speedButtons ? `
+      <div class="button-row">
+        ${renderActionButton(device, 'DecreaseSpeed', 'Speed Down', false, 'secondary-button')}
+        ${renderActionButton(device, 'IncreaseSpeed', 'Speed Up', false, 'secondary-button')}
+      </div>
+    ` : ''}
+    ${capabilities.direction ? renderActionButton(device, 'ToggleDirection', device.state.direction === 1 ? 'Reverse' : 'Forward', false, 'secondary-button') : ''}
+    ${renderLightControls(device, capabilities)}
+  `;
+}
+
+function renderDeviceControl(device) {
+  const capabilities = deviceCapabilities(device);
+  const controls = capabilities.fan ? renderFanControls(device, capabilities) : renderLightControls(device, capabilities);
 
   return `
     <article class="panel control-panel">
@@ -34,17 +101,7 @@ function renderDeviceControl(device) {
         <h2>${device.name}</h2>
         <p class="device-meta">${device.id} · ${device.type}</p>
       </div>
-      <button class="power-button" data-action="toggle" data-device-id="${device.id}" type="button" aria-pressed="${lightOn}">
-        <span class="power-icon"></span>
-        <span>${lightOn ? 'Turn Off' : 'Turn On'}</span>
-      </button>
-      ${capabilities.brightness ? `
-        <label class="slider-control">
-          <span>Brightness</span>
-          <strong>${brightness}%</strong>
-          <input data-action="brightness" data-device-id="${device.id}" type="range" min="1" max="100" value="${brightness}">
-        </label>
-      ` : ''}
+      ${controls}
     </article>
   `;
 }
@@ -85,14 +142,23 @@ async function refresh() {
 }
 
 elements.deviceControls.addEventListener('click', async (event) => {
-  const button = event.target.closest('[data-action="toggle"]');
+  const button = event.target.closest('[data-action="bond-action"]');
   if (!button) {
     return;
   }
 
   button.disabled = true;
   try {
-    render(await request(`/simulator/toggle?id=${button.dataset.deviceId}`, { method: 'PUT' }));
+    render(await request('/simulator/action', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        id: button.dataset.deviceId,
+        action: button.dataset.bondAction,
+      }),
+    }));
   } finally {
     button.disabled = false;
   }
@@ -114,6 +180,30 @@ elements.deviceControls.addEventListener('change', async (event) => {
       body: JSON.stringify({
         id: slider.dataset.deviceId,
         brightness: Number(slider.value),
+      }),
+    }));
+  } finally {
+    slider.disabled = false;
+  }
+});
+
+elements.deviceControls.addEventListener('change', async (event) => {
+  const slider = event.target.closest('[data-action="speed"]');
+  if (!slider) {
+    return;
+  }
+
+  slider.disabled = true;
+  try {
+    render(await request('/simulator/action', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        id: slider.dataset.deviceId,
+        action: 'SetSpeed',
+        argument: Number(slider.value),
       }),
     }));
   } finally {

--- a/tools/bond-simulator/static/app.js
+++ b/tools/bond-simulator/static/app.js
@@ -19,12 +19,15 @@ async function request(path, options) {
 function deviceCapabilities(device) {
   return {
     fan: device.type === 'CF',
+    shade: device.type === 'MS',
     speed: device.actions.includes('SetSpeed'),
     speedButtons: device.actions.includes('IncreaseSpeed') && device.actions.includes('DecreaseSpeed'),
     direction: device.actions.includes('ToggleDirection'),
     light: device.actions.includes('ToggleLight'),
     upDownLight: device.actions.includes('ToggleUpLight') && device.actions.includes('ToggleDownLight'),
     brightness: device.actions.includes('SetBrightness') && device.actions.includes('TurnLightOff'),
+    position: device.actions.includes('SetPosition'),
+    preset: device.actions.includes('Preset'),
   };
 }
 
@@ -90,9 +93,28 @@ function renderFanControls(device, capabilities) {
   `;
 }
 
+function renderShadeControls(device, capabilities) {
+  const open = device.state.open === 1;
+  const position = device.state.position ?? (open ? 0 : 100);
+
+  return `
+    ${renderActionButton(device, 'ToggleOpen', open ? 'Close' : 'Open', open)}
+    ${capabilities.position ? `
+      <label class="slider-control">
+        <span>Position</span>
+        <strong>${position}%</strong>
+        <input data-action="position" data-device-id="${device.id}" type="range" min="0" max="100" value="${position}">
+      </label>
+    ` : ''}
+    ${capabilities.preset ? renderActionButton(device, 'Preset', 'Preset', false, 'secondary-button') : ''}
+  `;
+}
+
 function renderDeviceControl(device) {
   const capabilities = deviceCapabilities(device);
-  const controls = capabilities.fan ? renderFanControls(device, capabilities) : renderLightControls(device, capabilities);
+  const controls = capabilities.shade
+    ? renderShadeControls(device, capabilities)
+    : capabilities.fan ? renderFanControls(device, capabilities) : renderLightControls(device, capabilities);
 
   return `
     <article class="panel control-panel">
@@ -203,6 +225,30 @@ elements.deviceControls.addEventListener('change', async (event) => {
       body: JSON.stringify({
         id: slider.dataset.deviceId,
         action: 'SetSpeed',
+        argument: Number(slider.value),
+      }),
+    }));
+  } finally {
+    slider.disabled = false;
+  }
+});
+
+elements.deviceControls.addEventListener('change', async (event) => {
+  const slider = event.target.closest('[data-action="position"]');
+  if (!slider) {
+    return;
+  }
+
+  slider.disabled = true;
+  try {
+    render(await request('/simulator/action', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        id: slider.dataset.deviceId,
+        action: 'SetPosition',
         argument: Number(slider.value),
       }),
     }));

--- a/tools/bond-simulator/static/app.js
+++ b/tools/bond-simulator/static/app.js
@@ -1,15 +1,10 @@
 const elements = {
   status: document.getElementById('connection-status'),
-  lightState: document.getElementById('light-state'),
-  toggleLight: document.getElementById('toggle-light'),
-  toggleLabel: document.getElementById('toggle-label'),
   bondId: document.getElementById('bond-id'),
   firmware: document.getElementById('firmware'),
   token: document.getElementById('token'),
-  deviceId: document.getElementById('device-id'),
-  deviceName: document.getElementById('device-name'),
-  deviceLocation: document.getElementById('device-location'),
-  deviceType: document.getElementById('device-type'),
+  deviceControls: document.getElementById('device-controls'),
+  deviceList: document.getElementById('device-list'),
   homebridgeConfig: document.getElementById('homebridge-config'),
 };
 
@@ -21,20 +16,62 @@ async function request(path, options) {
   return response.json();
 }
 
+function deviceCapabilities(device) {
+  return {
+    brightness: device.actions.includes('SetBrightness') && device.actions.includes('TurnLightOff'),
+  };
+}
+
+function renderDeviceControl(device) {
+  const lightOn = device.state.light === 1;
+  const capabilities = deviceCapabilities(device);
+  const brightness = device.state.brightness ?? 0;
+
+  return `
+    <article class="panel control-panel">
+      <div class="device-heading">
+        <p class="label">${device.location}</p>
+        <h2>${device.name}</h2>
+        <p class="device-meta">${device.id} · ${device.type}</p>
+      </div>
+      <button class="power-button" data-action="toggle" data-device-id="${device.id}" type="button" aria-pressed="${lightOn}">
+        <span class="power-icon"></span>
+        <span>${lightOn ? 'Turn Off' : 'Turn On'}</span>
+      </button>
+      ${capabilities.brightness ? `
+        <label class="slider-control">
+          <span>Brightness</span>
+          <strong>${brightness}%</strong>
+          <input data-action="brightness" data-device-id="${device.id}" type="range" min="1" max="100" value="${brightness}">
+        </label>
+      ` : ''}
+    </article>
+  `;
+}
+
+function renderDeviceSummary(device) {
+  const actions = device.actions.join(', ');
+  const state = Object.entries(device.state)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join(', ');
+
+  return `
+    <div class="device-summary">
+      <strong>${device.name}</strong>
+      <span>${device.id} · ${actions}</span>
+      <span>${state}</span>
+    </div>
+  `;
+}
+
 function render(status) {
-  const lightOn = status.device.state.light === 1;
   elements.status.textContent = 'Online';
   elements.status.className = 'status online';
-  elements.lightState.textContent = lightOn ? 'On' : 'Off';
-  elements.toggleLight.setAttribute('aria-pressed', String(lightOn));
-  elements.toggleLabel.textContent = lightOn ? 'Turn Off' : 'Turn On';
   elements.bondId.textContent = status.version.bondid;
   elements.firmware.textContent = status.version.fw_ver;
   elements.token.textContent = status.token;
-  elements.deviceId.textContent = status.device.id;
-  elements.deviceName.textContent = status.device.name;
-  elements.deviceLocation.textContent = status.device.location;
-  elements.deviceType.textContent = status.device.type;
+  elements.deviceControls.innerHTML = status.devices.map(renderDeviceControl).join('');
+  elements.deviceList.innerHTML = status.devices.map(renderDeviceSummary).join('');
   elements.homebridgeConfig.textContent = JSON.stringify(status.homebridgeConfig, null, 2);
 }
 
@@ -47,12 +84,40 @@ async function refresh() {
   }
 }
 
-elements.toggleLight.addEventListener('click', async () => {
-  elements.toggleLight.disabled = true;
+elements.deviceControls.addEventListener('click', async (event) => {
+  const button = event.target.closest('[data-action="toggle"]');
+  if (!button) {
+    return;
+  }
+
+  button.disabled = true;
   try {
-    render(await request('/simulator/toggle', { method: 'PUT' }));
+    render(await request(`/simulator/toggle?id=${button.dataset.deviceId}`, { method: 'PUT' }));
   } finally {
-    elements.toggleLight.disabled = false;
+    button.disabled = false;
+  }
+});
+
+elements.deviceControls.addEventListener('change', async (event) => {
+  const slider = event.target.closest('[data-action="brightness"]');
+  if (!slider) {
+    return;
+  }
+
+  slider.disabled = true;
+  try {
+    render(await request('/simulator/brightness', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        id: slider.dataset.deviceId,
+        brightness: Number(slider.value),
+      }),
+    }));
+  } finally {
+    slider.disabled = false;
   }
 });
 

--- a/tools/bond-simulator/static/app.js
+++ b/tools/bond-simulator/static/app.js
@@ -138,7 +138,7 @@ function renderDeviceControl(device) {
   return `
     <article class="panel control-panel">
       <div class="device-heading">
-        <p class="label">${device.location}</p>
+        ${device.location ? `<p class="label">${device.location}</p>` : ''}
         <h2>${device.name}</h2>
         <p class="device-meta">${device.id} · ${device.type}</p>
       </div>

--- a/tools/bond-simulator/static/app.js
+++ b/tools/bond-simulator/static/app.js
@@ -1,0 +1,60 @@
+const elements = {
+  status: document.getElementById('connection-status'),
+  lightState: document.getElementById('light-state'),
+  toggleLight: document.getElementById('toggle-light'),
+  toggleLabel: document.getElementById('toggle-label'),
+  bondId: document.getElementById('bond-id'),
+  firmware: document.getElementById('firmware'),
+  token: document.getElementById('token'),
+  deviceId: document.getElementById('device-id'),
+  deviceName: document.getElementById('device-name'),
+  deviceLocation: document.getElementById('device-location'),
+  deviceType: document.getElementById('device-type'),
+  homebridgeConfig: document.getElementById('homebridge-config'),
+};
+
+async function request(path, options) {
+  const response = await fetch(path, options);
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+function render(status) {
+  const lightOn = status.device.state.light === 1;
+  elements.status.textContent = 'Online';
+  elements.status.className = 'status online';
+  elements.lightState.textContent = lightOn ? 'On' : 'Off';
+  elements.toggleLight.setAttribute('aria-pressed', String(lightOn));
+  elements.toggleLabel.textContent = lightOn ? 'Turn Off' : 'Turn On';
+  elements.bondId.textContent = status.version.bondid;
+  elements.firmware.textContent = status.version.fw_ver;
+  elements.token.textContent = status.token;
+  elements.deviceId.textContent = status.device.id;
+  elements.deviceName.textContent = status.device.name;
+  elements.deviceLocation.textContent = status.device.location;
+  elements.deviceType.textContent = status.device.type;
+  elements.homebridgeConfig.textContent = JSON.stringify(status.homebridgeConfig, null, 2);
+}
+
+async function refresh() {
+  try {
+    render(await request('/simulator/status'));
+  } catch (error) {
+    elements.status.textContent = 'Offline';
+    elements.status.className = 'status error';
+  }
+}
+
+elements.toggleLight.addEventListener('click', async () => {
+  elements.toggleLight.disabled = true;
+  try {
+    render(await request('/simulator/toggle', { method: 'PUT' }));
+  } finally {
+    elements.toggleLight.disabled = false;
+  }
+});
+
+refresh();
+setInterval(refresh, 3000);

--- a/tools/bond-simulator/static/app.js
+++ b/tools/bond-simulator/static/app.js
@@ -20,6 +20,7 @@ function deviceCapabilities(device) {
   return {
     fan: device.type === 'CF',
     shade: device.type === 'MS',
+    fireplace: device.type === 'FP',
     speed: device.actions.includes('SetSpeed'),
     speedButtons: device.actions.includes('IncreaseSpeed') && device.actions.includes('DecreaseSpeed'),
     direction: device.actions.includes('ToggleDirection'),
@@ -28,6 +29,7 @@ function deviceCapabilities(device) {
     brightness: device.actions.includes('SetBrightness') && device.actions.includes('TurnLightOff'),
     position: device.actions.includes('SetPosition'),
     preset: device.actions.includes('Preset'),
+    flame: device.actions.includes('SetFlame'),
   };
 }
 
@@ -110,10 +112,27 @@ function renderShadeControls(device, capabilities) {
   `;
 }
 
+function renderFireplaceControls(device, capabilities) {
+  const powerOn = device.state.power === 1;
+  const flame = device.state.flame ?? 0;
+
+  return `
+    ${renderActionButton(device, 'TogglePower', powerOn ? 'Turn Off' : 'Turn On', powerOn)}
+    ${capabilities.flame ? `
+      <label class="slider-control">
+        <span>Flame</span>
+        <strong>${flame}%</strong>
+        <input data-action="flame" data-device-id="${device.id}" type="range" min="1" max="100" value="${flame}">
+      </label>
+    ` : ''}
+  `;
+}
+
 function renderDeviceControl(device) {
   const capabilities = deviceCapabilities(device);
   const controls = capabilities.shade
     ? renderShadeControls(device, capabilities)
+    : capabilities.fireplace ? renderFireplaceControls(device, capabilities)
     : capabilities.fan ? renderFanControls(device, capabilities) : renderLightControls(device, capabilities);
 
   return `
@@ -249,6 +268,30 @@ elements.deviceControls.addEventListener('change', async (event) => {
       body: JSON.stringify({
         id: slider.dataset.deviceId,
         action: 'SetPosition',
+        argument: Number(slider.value),
+      }),
+    }));
+  } finally {
+    slider.disabled = false;
+  }
+});
+
+elements.deviceControls.addEventListener('change', async (event) => {
+  const slider = event.target.closest('[data-action="flame"]');
+  if (!slider) {
+    return;
+  }
+
+  slider.disabled = true;
+  try {
+    render(await request('/simulator/action', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        id: slider.dataset.deviceId,
+        action: 'SetFlame',
         argument: Number(slider.value),
       }),
     }));

--- a/tools/bond-simulator/static/app.js
+++ b/tools/bond-simulator/static/app.js
@@ -7,6 +7,17 @@ const elements = {
   deviceList: document.getElementById('device-list'),
   homebridgeConfig: document.getElementById('homebridge-config'),
 };
+const previousExternalUpdates = new Map();
+let hasRendered = false;
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
 
 async function request(path, options) {
   const response = await fetch(path, options);
@@ -64,7 +75,7 @@ function renderLightControls(device, capabilities) {
       <label class="slider-control">
         <span>Brightness</span>
         <strong>${brightness}%</strong>
-        <input data-action="brightness" data-device-id="${device.id}" type="range" min="1" max="100" value="${brightness}">
+        <input data-action="brightness" data-device-id="${device.id}" type="range" min="0" max="100" value="${brightness}">
       </label>
     ` : ''}
   `;
@@ -81,7 +92,7 @@ function renderFanControls(device, capabilities) {
       <label class="slider-control">
         <span>Speed</span>
         <strong>${speed} / ${maxSpeed}</strong>
-        <input data-action="speed" data-device-id="${device.id}" type="range" min="1" max="${maxSpeed}" value="${speed}">
+        <input data-action="speed" data-device-id="${device.id}" type="range" min="0" max="${maxSpeed}" value="${speed}">
       </label>
     ` : ''}
     ${capabilities.speedButtons ? `
@@ -122,13 +133,30 @@ function renderFireplaceControls(device, capabilities) {
       <label class="slider-control">
         <span>Flame</span>
         <strong>${flame}%</strong>
-        <input data-action="flame" data-device-id="${device.id}" type="range" min="1" max="100" value="${flame}">
+        <input data-action="flame" data-device-id="${device.id}" type="range" min="0" max="100" value="${flame}">
       </label>
     ` : ''}
   `;
 }
 
-function renderDeviceControl(device) {
+function deviceTypeLabel(type) {
+  return {
+    LT: 'Lights',
+    CF: 'Fans',
+    MS: 'Shades',
+    FP: 'Fireplaces',
+  }[type] ?? 'Other';
+}
+
+function renderDeviceState(device) {
+  const state = Object.entries(device.state)
+    .map(([key, value]) => `<span><b>${escapeHtml(key)}</b>${escapeHtml(value)}</span>`)
+    .join('');
+
+  return `<div class="state-pills">${state}</div>`;
+}
+
+function renderDeviceControl(device, highlight) {
   const capabilities = deviceCapabilities(device);
   const controls = capabilities.shade
     ? renderShadeControls(device, capabilities)
@@ -136,14 +164,28 @@ function renderDeviceControl(device) {
     : capabilities.fan ? renderFanControls(device, capabilities) : renderLightControls(device, capabilities);
 
   return `
-    <article class="panel control-panel">
+    <article class="panel control-panel ${highlight ? 'external-update' : ''}" data-device-id="${device.id}">
       <div class="device-heading">
-        ${device.location ? `<p class="label">${device.location}</p>` : ''}
         <h2>${device.name}</h2>
-        <p class="device-meta">${device.id} · ${device.type}</p>
+        <p class="device-meta">${device.id} · ${device.type}${device.subtype ? ` · ${device.subtype}` : ''}</p>
+        ${renderDeviceState(device)}
       </div>
       ${controls}
     </article>
+  `;
+}
+
+function renderDeviceGroup(type, devices, highlights) {
+  return `
+    <section class="device-section">
+      <div class="section-heading">
+        <h2>${deviceTypeLabel(type)}</h2>
+        <span>${devices.length}</span>
+      </div>
+      <div class="device-grid">
+        ${devices.map(device => renderDeviceControl(device, highlights.has(device.id))).join('')}
+      </div>
+    </section>
   `;
 }
 
@@ -163,14 +205,40 @@ function renderDeviceSummary(device) {
 }
 
 function render(status) {
+  const highlights = new Set();
+  const grouped = status.devices.reduce((acc, device) => {
+    if (!acc.has(device.type)) {
+      acc.set(device.type, []);
+    }
+    acc.get(device.type).push(device);
+
+    if (
+      hasRendered
+      && device.lastUpdatedBy === 'external'
+      && device.lastUpdatedAt > (previousExternalUpdates.get(device.id) ?? 0)
+    ) {
+      highlights.add(device.id);
+    }
+    if (device.lastUpdatedBy === 'external') {
+      previousExternalUpdates.set(device.id, device.lastUpdatedAt);
+    }
+
+    return acc;
+  }, new Map());
+  const typeOrder = ['LT', 'CF', 'MS', 'FP'];
+
   elements.status.textContent = 'Online';
   elements.status.className = 'status online';
   elements.bondId.textContent = status.version.bondid;
   elements.firmware.textContent = status.version.fw_ver;
   elements.token.textContent = status.token;
-  elements.deviceControls.innerHTML = status.devices.map(renderDeviceControl).join('');
+  elements.deviceControls.innerHTML = typeOrder
+    .filter(type => grouped.has(type))
+    .map(type => renderDeviceGroup(type, grouped.get(type), highlights))
+    .join('');
   elements.deviceList.innerHTML = status.devices.map(renderDeviceSummary).join('');
   elements.homebridgeConfig.textContent = JSON.stringify(status.homebridgeConfig, null, 2);
+  hasRendered = true;
 }
 
 async function refresh() {

--- a/tools/bond-simulator/static/index.html
+++ b/tools/bond-simulator/static/index.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Bond Simulator</title>
+    <link rel="stylesheet" href="/static/styles.css">
+  </head>
+  <body>
+    <main class="shell">
+      <header class="masthead">
+        <div>
+          <p class="eyebrow">homebridge-bond</p>
+          <h1>Bond Simulator</h1>
+        </div>
+        <div class="status" id="connection-status">Connecting</div>
+      </header>
+
+      <section class="panel control-panel">
+        <div>
+          <p class="label">Simulator Light</p>
+          <h2 id="light-state">Unknown</h2>
+        </div>
+        <button class="power-button" id="toggle-light" type="button" aria-pressed="false">
+          <span class="power-icon"></span>
+          <span id="toggle-label">Toggle</span>
+        </button>
+      </section>
+
+      <section class="grid">
+        <div class="panel">
+          <h2>Hub</h2>
+          <dl>
+            <div>
+              <dt>Bond ID</dt>
+              <dd id="bond-id">-</dd>
+            </div>
+            <div>
+              <dt>Firmware</dt>
+              <dd id="firmware">-</dd>
+            </div>
+            <div>
+              <dt>Token</dt>
+              <dd id="token">-</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div class="panel">
+          <h2>Device</h2>
+          <dl>
+            <div>
+              <dt>ID</dt>
+              <dd id="device-id">-</dd>
+            </div>
+            <div>
+              <dt>Name</dt>
+              <dd id="device-name">-</dd>
+            </div>
+            <div>
+              <dt>Location</dt>
+              <dd id="device-location">-</dd>
+            </div>
+            <div>
+              <dt>Type</dt>
+              <dd id="device-type">-</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Homebridge Config</h2>
+        <pre id="homebridge-config">{}</pre>
+      </section>
+    </main>
+
+    <script src="/static/app.js"></script>
+  </body>
+</html>

--- a/tools/bond-simulator/static/index.html
+++ b/tools/bond-simulator/static/index.html
@@ -16,16 +16,7 @@
         <div class="status" id="connection-status">Connecting</div>
       </header>
 
-      <section class="panel control-panel">
-        <div>
-          <p class="label">Simulator Light</p>
-          <h2 id="light-state">Unknown</h2>
-        </div>
-        <button class="power-button" id="toggle-light" type="button" aria-pressed="false">
-          <span class="power-icon"></span>
-          <span id="toggle-label">Toggle</span>
-        </button>
-      </section>
+      <section class="device-grid" id="device-controls"></section>
 
       <section class="grid">
         <div class="panel">
@@ -47,25 +38,8 @@
         </div>
 
         <div class="panel">
-          <h2>Device</h2>
-          <dl>
-            <div>
-              <dt>ID</dt>
-              <dd id="device-id">-</dd>
-            </div>
-            <div>
-              <dt>Name</dt>
-              <dd id="device-name">-</dd>
-            </div>
-            <div>
-              <dt>Location</dt>
-              <dd id="device-location">-</dd>
-            </div>
-            <div>
-              <dt>Type</dt>
-              <dd id="device-type">-</dd>
-            </div>
-          </dl>
+          <h2>Devices</h2>
+          <div class="device-list" id="device-list"></div>
         </div>
       </section>
 

--- a/tools/bond-simulator/static/index.html
+++ b/tools/bond-simulator/static/index.html
@@ -16,7 +16,7 @@
         <div class="status" id="connection-status">Connecting</div>
       </header>
 
-      <section class="device-grid" id="device-controls"></section>
+      <section class="device-groups" id="device-controls"></section>
 
       <section class="grid">
         <div class="panel">

--- a/tools/bond-simulator/static/index.html
+++ b/tools/bond-simulator/static/index.html
@@ -18,34 +18,26 @@
 
       <section class="device-groups" id="device-controls"></section>
 
-      <section class="grid">
-        <div class="panel">
-          <h2>Hub</h2>
-          <dl>
-            <div>
-              <dt>Bond ID</dt>
-              <dd id="bond-id">-</dd>
-            </div>
-            <div>
-              <dt>Firmware</dt>
-              <dd id="firmware">-</dd>
-            </div>
-            <div>
-              <dt>Token</dt>
-              <dd id="token">-</dd>
-            </div>
-          </dl>
-        </div>
-
-        <div class="panel">
-          <h2>Devices</h2>
-          <div class="device-list" id="device-list"></div>
-        </div>
-      </section>
-
-      <section class="panel">
-        <h2>Homebridge Config</h2>
-        <pre id="homebridge-config">{}</pre>
+      <section class="panel hub-panel">
+        <h2>Hub</h2>
+        <dl>
+          <div>
+            <dt>IP Address</dt>
+            <dd id="ip-address">-</dd>
+          </div>
+          <div>
+            <dt>Bond ID</dt>
+            <dd id="bond-id">-</dd>
+          </div>
+          <div>
+            <dt>Firmware</dt>
+            <dd id="firmware">-</dd>
+          </div>
+          <div>
+            <dt>Token</dt>
+            <dd id="token">-</dd>
+          </div>
+        </dl>
       </section>
     </main>
 

--- a/tools/bond-simulator/static/styles.css
+++ b/tools/bond-simulator/static/styles.css
@@ -1,0 +1,208 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f7f2;
+  --panel: #ffffff;
+  --ink: #20251f;
+  --muted: #687066;
+  --line: #d9dfd3;
+  --accent: #1f7a68;
+  --accent-dark: #145448;
+  --warn: #a44621;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.shell {
+  width: min(980px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 32px 0;
+}
+
+.masthead,
+.control-panel,
+.grid {
+  display: grid;
+  gap: 16px;
+}
+
+.masthead {
+  grid-template-columns: 1fr auto;
+  align-items: end;
+  margin-bottom: 20px;
+}
+
+.eyebrow,
+.label {
+  margin: 0 0 6px;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  margin: 0;
+  letter-spacing: 0;
+}
+
+h1 {
+  font-size: 40px;
+  line-height: 1.05;
+}
+
+h2 {
+  font-size: 22px;
+}
+
+.status {
+  min-width: 112px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--muted);
+  font-size: 14px;
+  text-align: center;
+}
+
+.status.online {
+  border-color: rgba(31, 122, 104, 0.32);
+  color: var(--accent-dark);
+}
+
+.status.error {
+  border-color: rgba(164, 70, 33, 0.32);
+  color: var(--warn);
+}
+
+.panel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  padding: 20px;
+}
+
+.control-panel {
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.power-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-width: 148px;
+  min-height: 48px;
+  border: 0;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #ffffff;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.power-button[aria-pressed="true"] {
+  background: var(--accent-dark);
+}
+
+.power-button:disabled {
+  cursor: wait;
+  opacity: 0.68;
+}
+
+.power-icon {
+  width: 17px;
+  height: 17px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 999px;
+  position: relative;
+}
+
+.power-icon::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: -8px;
+  width: 2px;
+  height: 11px;
+  border-radius: 999px;
+  background: currentColor;
+  transform: translateX(-50%);
+}
+
+.grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-bottom: 16px;
+}
+
+dl {
+  display: grid;
+  gap: 12px;
+  margin: 16px 0 0;
+}
+
+dl div {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 12px;
+  align-items: baseline;
+}
+
+dt {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+pre {
+  min-height: 132px;
+  margin: 16px 0 0;
+  padding: 16px;
+  overflow: auto;
+  border-radius: 8px;
+  background: #18211e;
+  color: #edf5ef;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+@media (max-width: 720px) {
+  .masthead,
+  .control-panel,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .masthead {
+    align-items: stretch;
+  }
+
+  h1 {
+    font-size: 34px;
+  }
+
+  .power-button {
+    width: 100%;
+  }
+}

--- a/tools/bond-simulator/static/styles.css
+++ b/tools/bond-simulator/static/styles.css
@@ -23,13 +23,12 @@ body {
 }
 
 .shell {
-  width: min(980px, calc(100vw - 32px));
+  width: min(1380px, calc(100vw - 32px));
   margin: 0 auto;
   padding: 32px 0;
 }
 
 .masthead,
-.device-grid,
 .grid {
   display: grid;
   gap: 16px;
@@ -63,7 +62,7 @@ h1 {
 }
 
 h2 {
-  font-size: 22px;
+  font-size: 18px;
 }
 
 .status {
@@ -91,20 +90,62 @@ h2 {
   border: 1px solid var(--line);
   border-radius: 8px;
   background: var(--panel);
-  padding: 20px;
+  padding: 16px;
+}
+
+.device-groups {
+  margin-bottom: 16px;
+}
+
+.device-section {
+  margin-bottom: 22px;
+}
+
+.section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0 0 10px;
+}
+
+.section-heading span {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 800;
 }
 
 .device-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  margin-bottom: 16px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
 }
 
 .control-panel {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr);
   align-items: start;
-  gap: 16px;
-  min-height: 178px;
+  gap: 12px;
+  min-height: 0;
+  transition: border-color 180ms ease, box-shadow 180ms ease, background-color 180ms ease;
+}
+
+.control-panel.external-update {
+  animation: external-update 1600ms ease-out;
+}
+
+@keyframes external-update {
+  0% {
+    border-color: rgba(31, 122, 104, 0.9);
+    background: #edf8f4;
+    box-shadow: 0 0 0 3px rgba(31, 122, 104, 0.18);
+  }
+
+  100% {
+    border-color: var(--line);
+    background: var(--panel);
+    box-shadow: 0 0 0 0 rgba(31, 122, 104, 0);
+  }
 }
 
 .device-heading {
@@ -112,9 +153,34 @@ h2 {
 }
 
 .device-meta {
-  margin: 8px 0 0;
+  margin: 6px 0 0;
   color: var(--muted);
   font-size: 13px;
+}
+
+.state-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.state-pills span {
+  display: inline-flex;
+  gap: 5px;
+  align-items: center;
+  min-height: 24px;
+  padding: 3px 7px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.state-pills b {
+  color: var(--ink);
+  font-weight: 800;
 }
 
 .power-button {
@@ -122,8 +188,9 @@ h2 {
   align-items: center;
   justify-content: center;
   gap: 10px;
-  min-width: 148px;
-  min-height: 48px;
+  width: 100%;
+  min-width: 0;
+  min-height: 40px;
   border: 0;
   border-radius: 8px;
   background: var(--accent);
@@ -149,17 +216,15 @@ h2 {
 }
 
 .button-row {
-  display: flex;
-  flex-wrap: wrap;
-  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
 }
 
 .slider-control {
   display: grid;
-  grid-column: 1 / -1;
   grid-template-columns: 1fr auto;
-  gap: 10px;
+  gap: 8px;
   align-items: center;
 }
 
@@ -263,12 +328,7 @@ pre {
 
 @media (max-width: 720px) {
   .masthead,
-  .device-grid,
   .grid {
-    grid-template-columns: 1fr;
-  }
-
-  .control-panel {
     grid-template-columns: 1fr;
   }
 
@@ -280,11 +340,4 @@ pre {
     font-size: 34px;
   }
 
-  .power-button {
-    width: 100%;
-  }
-
-  .control-panel {
-    grid-template-columns: 1fr;
-  }
 }

--- a/tools/bond-simulator/static/styles.css
+++ b/tools/bond-simulator/static/styles.css
@@ -29,7 +29,7 @@ body {
 }
 
 .masthead,
-.control-panel,
+.device-grid,
 .grid {
   display: grid;
   gap: 16px;
@@ -94,10 +94,27 @@ h2 {
   padding: 20px;
 }
 
+.device-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-bottom: 16px;
+}
+
 .control-panel {
+  display: grid;
   grid-template-columns: 1fr auto;
   align-items: center;
-  margin-bottom: 16px;
+  gap: 16px;
+  min-height: 178px;
+}
+
+.device-heading {
+  min-width: 0;
+}
+
+.device-meta {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 13px;
 }
 
 .power-button {
@@ -125,6 +142,26 @@ h2 {
   opacity: 0.68;
 }
 
+.slider-control {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.slider-control span {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.slider-control input {
+  grid-column: 1 / -1;
+  width: 100%;
+  accent-color: var(--accent);
+}
+
 .power-icon {
   width: 17px;
   height: 17px;
@@ -149,6 +186,30 @@ h2 {
 .grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   margin-bottom: 16px;
+}
+
+.device-list {
+  display: grid;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.device-summary {
+  display: grid;
+  gap: 4px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.device-summary:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.device-summary span {
+  color: var(--muted);
+  font-size: 13px;
+  overflow-wrap: anywhere;
 }
 
 dl {
@@ -189,7 +250,7 @@ pre {
 
 @media (max-width: 720px) {
   .masthead,
-  .control-panel,
+  .device-grid,
   .grid {
     grid-template-columns: 1fr;
   }
@@ -204,5 +265,9 @@ pre {
 
   .power-button {
     width: 100%;
+  }
+
+  .control-panel {
+    grid-template-columns: 1fr;
   }
 }

--- a/tools/bond-simulator/static/styles.css
+++ b/tools/bond-simulator/static/styles.css
@@ -101,8 +101,8 @@ h2 {
 
 .control-panel {
   display: grid;
-  grid-template-columns: 1fr auto;
-  align-items: center;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
   gap: 16px;
   min-height: 178px;
 }
@@ -140,6 +140,19 @@ h2 {
 .power-button:disabled {
   cursor: wait;
   opacity: 0.68;
+}
+
+.secondary-button {
+  border: 1px solid var(--line);
+  background: #ffffff;
+  color: var(--accent-dark);
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  grid-column: 1 / -1;
+  gap: 10px;
 }
 
 .slider-control {
@@ -252,6 +265,10 @@ pre {
   .masthead,
   .device-grid,
   .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .control-panel {
     grid-template-columns: 1fr;
   }
 

--- a/tools/bond-simulator/static/styles.css
+++ b/tools/bond-simulator/static/styles.css
@@ -94,11 +94,17 @@ h2 {
 }
 
 .device-groups {
-  margin-bottom: 16px;
+  margin-bottom: 24px;
 }
 
 .device-section {
-  margin-bottom: 22px;
+  padding: 24px 0 28px;
+  border-top: 1px solid var(--line);
+}
+
+.device-section:first-child {
+  padding-top: 0;
+  border-top: 0;
 }
 
 .section-heading {
@@ -106,7 +112,7 @@ h2 {
   align-items: baseline;
   justify-content: space-between;
   gap: 12px;
-  margin: 0 0 10px;
+  margin: 0 0 14px;
 }
 
 .section-heading span {
@@ -130,26 +136,67 @@ h2 {
   transition: border-color 180ms ease, box-shadow 180ms ease, background-color 180ms ease;
 }
 
+.control-panel.is-on {
+  border-color: rgba(31, 122, 104, 0.38);
+  background: #eaf6f1;
+}
+
+.control-panel.is-off {
+  background: #ffffff;
+}
+
+.control-panel:hover {
+  border-color: rgba(31, 122, 104, 0.42);
+  box-shadow: 0 1px 8px rgba(32, 37, 31, 0.08);
+}
+
 .control-panel.external-update {
   animation: external-update 1600ms ease-out;
 }
 
 @keyframes external-update {
   0% {
-    border-color: rgba(31, 122, 104, 0.9);
-    background: #edf8f4;
-    box-shadow: 0 0 0 3px rgba(31, 122, 104, 0.18);
+    outline: 4px solid rgba(170, 92, 12, 0.2);
+    outline-offset: 0;
+  }
+
+  45% {
+    outline: 2px solid rgba(170, 92, 12, 0.16);
+    outline-offset: 2px;
   }
 
   100% {
-    border-color: var(--line);
-    background: var(--panel);
-    box-shadow: 0 0 0 0 rgba(31, 122, 104, 0);
+    outline: 0 solid rgba(170, 92, 12, 0);
+    outline-offset: 4px;
   }
 }
 
 .device-heading {
   min-width: 0;
+}
+
+.device-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.device-title-row h2 {
+  min-width: 0;
+}
+
+.update-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 3px 8px;
+  border: 1px solid rgba(170, 92, 12, 0.42);
+  border-radius: 999px;
+  background: #fff4df;
+  color: #7a3f06;
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1;
 }
 
 .device-meta {
@@ -183,36 +230,103 @@ h2 {
   font-weight: 800;
 }
 
-.power-button {
+.component-section {
+  display: grid;
+  gap: 10px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
+.component-section h3 {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.action-button,
+.toggle-control {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
   gap: 10px;
   width: 100%;
   min-width: 0;
   min-height: 40px;
-  border: 0;
+  border: 1px solid var(--line);
   border-radius: 8px;
-  background: var(--accent);
-  color: #ffffff;
+  background: #ffffff;
+  color: var(--ink);
   font: inherit;
   font-weight: 800;
   cursor: pointer;
 }
 
-.power-button[aria-pressed="true"] {
-  background: var(--accent-dark);
+.action-button {
+  justify-content: center;
+  color: var(--accent-dark);
 }
 
-.power-button:disabled {
+.action-button:disabled,
+.toggle-control:disabled {
   cursor: wait;
   opacity: 0.68;
 }
 
-.secondary-button {
-  border: 1px solid var(--line);
+.toggle-control {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  justify-content: stretch;
+  text-align: left;
+}
+
+.toggle-switch {
+  width: 38px;
+  height: 22px;
+  padding: 2px;
+  border-radius: 999px;
+  background: #cfd8cc;
+  transition: background 140ms ease;
+}
+
+.toggle-switch::before {
+  content: "";
+  display: block;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
   background: #ffffff;
+  box-shadow: 0 1px 2px rgba(32, 37, 31, 0.22);
+  transition: transform 140ms ease;
+}
+
+.toggle-control[aria-pressed="true"] .toggle-switch {
+  background: var(--accent);
+}
+
+.toggle-control[aria-pressed="true"] .toggle-switch::before {
+  transform: translateX(16px);
+}
+
+.toggle-state {
+  min-width: 58px;
+  color: var(--muted);
+  font-size: 13px;
+  text-align: right;
+}
+
+.toggle-label {
+  overflow-wrap: anywhere;
+}
+
+.secondary-button {
   color: var(--accent-dark);
+}
+
+.control-stack {
+  display: grid;
+  gap: 10px;
 }
 
 .button-row {
@@ -238,6 +352,7 @@ h2 {
   grid-column: 1 / -1;
   width: 100%;
   accent-color: var(--accent);
+  cursor: pointer;
 }
 
 .power-icon {
@@ -261,33 +376,8 @@ h2 {
   transform: translateX(-50%);
 }
 
-.grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  margin-bottom: 16px;
-}
-
-.device-list {
-  display: grid;
-  gap: 12px;
-  margin-top: 16px;
-}
-
-.device-summary {
-  display: grid;
-  gap: 4px;
-  padding-bottom: 12px;
-  border-bottom: 1px solid var(--line);
-}
-
-.device-summary:last-child {
-  padding-bottom: 0;
-  border-bottom: 0;
-}
-
-.device-summary span {
-  color: var(--muted);
-  font-size: 13px;
-  overflow-wrap: anywhere;
+.hub-panel {
+  max-width: 720px;
 }
 
 dl {


### PR DESCRIPTION
## Summary

Adds a local Bond simulator for exercising the Homebridge plugin against realistic Bond API device permutations. The simulator includes HTTP Bond API endpoints, BPUP-style state broadcasts, and a browser UI test harness for lights, fans, shades, fireplaces, and generic devices.

## What changed

- Added the `npm run simulator` workflow and simulator server under `tools/bond-simulator/`.
- Added simulator fixtures for supported device families and edge-case capability combinations.
- Added a component-oriented simulator UI with explicit controls for toggles, sliders, hold-style dimmer actions, and external update indicators.
- Added BPUP host/port handling and logging improvements.
- Added tests covering simulator endpoints, state transitions, BPUP broadcasts, capability permutations, and platform BPUP behavior.
- Adjusted light capability naming/handling for brightness support.

## Impact

This gives the project a local test harness for validating Homebridge Bond behavior without requiring physical Bond hardware for every capability shape. It also makes simulator cards more useful as a developer harness by separating device components and exposing discrete actions.

## Validation

- `node --check tools/bond-simulator/static/app.js`
- `npm run lint`
- `npm run build`
- `npm test` / 275 passing

## Notes

The simulator should not be started or restarted on the user's existing port during agent verification. For future UI/API checks, use a temporary HTTP-only simulator on a separate port and stop it afterward.