### PR TITLE
[codex] Harden BPUP packet parsing

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -269,11 +269,11 @@ export class BondPlatform implements DynamicPlatformPlugin {
 
     client.on('message', (message: Buffer, remote: { address: string; port: string }) => {
       const msg = message.toString().trim();
-      try {
-        const packet = JSON.parse(msg) as BPUPPacket;
+      const packet = this.parseBPUPPacket(msg);
+      if (packet) {
         log.debug(`UDP Message received from ${remote.address}:${remote.port} - ${msg}`);
         bond.receivedBPUPPacket(packet);
-      } catch (_error) {
+      } else {
         log.debug(`Malformed UDP payload from ${remote.address}:${remote.port}. Ignoring packet.`);
       }
     });
@@ -285,6 +285,19 @@ export class BondPlatform implements DynamicPlatformPlugin {
 
   private bpupHost(ipAddress: string): string {
     return new URL(`http://${ipAddress}`).hostname;
+  }
+
+  private parseBPUPPacket(message: string): BPUPPacket | undefined {
+    const jsonStart = message.indexOf('{');
+    if (jsonStart === -1) {
+      return undefined;
+    }
+
+    try {
+      return JSON.parse(message.slice(jsonStart)) as BPUPPacket;
+    } catch (_error) {
+      return undefined;
+    }
   }
 
   private bondForDevice(device: Device): Bond | undefined {

--- a/tests/platform.spec.ts
+++ b/tests/platform.spec.ts
@@ -114,6 +114,53 @@ describe('BondPlatform security hardening', () => {
     expect(malformedLog).to.not.be.undefined;
   });
 
+  it('routes BPUP packets with leading non-JSON bytes', () => {
+    const log = createMockLog();
+    const api = createMockApi() as any;
+    const config = {
+      include_dimmer: false,
+      fan_speed_values: false,
+      include_toggle_state: false,
+      bonds: [{ ip_address: '192.168.1.100', token: 'token' }],
+    } as any;
+
+    const platform = new BondPlatform(log as any, config, api);
+    const handlers: Record<string, (...args: any[]) => void> = {};
+    const fakeSocket = {
+      send: sinon.stub().callsFake((
+        _message: Buffer,
+        _offset: number,
+        _length: number,
+        _port: number,
+        _host: string,
+        callback: (error?: Error) => void,
+      ) => callback()),
+      on: sinon.stub().callsFake((event: string, callback: (...args: any[]) => void) => {
+        handlers[event] = callback;
+      }),
+    };
+
+    sinon.stub(dgram, 'createSocket').returns(fakeSocket as any);
+    sinon.stub(global, 'setInterval').returns(1 as any);
+    const bond = {
+      config: { ip_address: '192.168.1.100' },
+      receivedBPUPPacket: sinon.stub(),
+    };
+
+    (platform as any).setupBPUP(bond);
+    handlers.message(
+      Buffer.from(`\uFFFDjunk${JSON.stringify({ B: 'ZZEC17318', d: 0, v: 'v3.8.4' })}`),
+      { address: '192.168.1.10', port: '30007' },
+    );
+
+    expect((bond.receivedBPUPPacket as sinon.SinonStub).calledOnce).to.equal(true);
+    expect((bond.receivedBPUPPacket as sinon.SinonStub).firstCall.args[0]).to.deep.equal({
+      B: 'ZZEC17318',
+      d: 0,
+      v: 'v3.8.4',
+    });
+  });
+
   it('strips HTTP port from BPUP UDP host', () => {
     const log = createMockLog();
     const api = createMockApi() as any;


### PR DESCRIPTION
## Summary
- Harden BPUP UDP message handling by parsing from the first JSON object marker instead of assuming the whole datagram is JSON.
- Keep malformed BPUP packets from reaching accessory state updates while continuing to log and ignore them.
- Add a regression test for packets with leading non-JSON bytes followed by a valid Bond payload.

## Why
Issue #239 reports malformed UDP payloads crashing the plugin during `JSON.parse`. Current code already ignores fully malformed packets, but valid BPUP JSON can still be preceded by stray bytes. This preserves the valid packet when possible and keeps bad packets non-fatal.

Fixes #239

## Validation
- `npm test -- --grep "BondPlatform security hardening"`
- `npm run lint`
- `npm run build`
- `npm test`