### PR TITLE
[codex] Limit concurrent Bond API requests

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -43,6 +43,13 @@
               "placeholder": "1000",
               "required": false,
               "description": "This will space out commands sent by the Bond by at least this many milliseconds."
+            },
+            "max_concurrent_requests": {
+              "title": "Max concurrent requests",
+              "type": "number",
+              "placeholder": "5",
+              "required": false,
+              "description": "Maximum number of HTTP requests to send to this Bond at the same time. Lower this if startup device discovery times out on large installations."
             }
           }
         }

--- a/src/BondApi.ts
+++ b/src/BondApi.ts
@@ -19,11 +19,15 @@ enum HTTPMethod {
 }
 
 const flakeIdGen = new FlakeId();
+const DEFAULT_MAX_CONCURRENT_REQUESTS = 5;
 
 export class BondApi {
   private bondToken: string;
   private uri: BondUri;
   private ms_between_actions?: number;
+  private maxConcurrentRequests: number;
+  private activeRequests = 0;
+  private pendingRequests: Array<() => void> = [];
   private queueNextRequest = false;
   private requestQueue: {device: Device, action: Action, body: unknown}[] = [];
 
@@ -39,10 +43,12 @@ export class BondApi {
     private readonly platform: BondPlatform,
     bondToken: string,
     ipAddress: string,
-    ms_between_actions?: number) {
+    ms_between_actions?: number,
+    max_concurrent_requests = DEFAULT_MAX_CONCURRENT_REQUESTS) {
     this.bondToken = bondToken;
     this.uri = new BondUri(ipAddress);
     this.ms_between_actions = ms_between_actions;
+    this.maxConcurrentRequests = max_concurrent_requests;
 
     axiosRetry(axios, {
       retries: 10,
@@ -283,6 +289,28 @@ export class BondApi {
 
   // Helpers
 
+  private acquireRequestSlot(): Promise<void> {
+    if (this.activeRequests < this.maxConcurrentRequests) {
+      this.activeRequests++;
+      return Promise.resolve();
+    }
+
+    return new Promise(resolve => {
+      this.pendingRequests.push(() => {
+        this.activeRequests++;
+        resolve();
+      });
+    });
+  }
+
+  private releaseRequestSlot(): void {
+    this.activeRequests--;
+    const next = this.pendingRequests.shift();
+    if (next) {
+      next();
+    }
+  }
+
   ping(): Promise<any> {
     const uuid = intformat(flakeIdGen.next(), 'hex', { prefix: '18', padstr: '0', size: 16 }); // avoid duplicate action
     const bondUuid = uuid.substring(0, 13) + uuid.substring(15); // remove '00' used for datacenter/worker in flakeIdGen
@@ -308,16 +336,17 @@ export class BondApi {
       this.platform.log.debug(`Request (${bondUuid}) [${method} ${uri}]`);
     }
 
-    return axios({
-      method,
-      url: uri,
-      headers: {
-        'BOND-Token': this.bondToken,
-        'Bond-UUID': bondUuid,
-      },
-      data: body,
-      timeout: 10000,
-    })
+    return this.acquireRequestSlot()
+      .then(() => axios({
+        method,
+        url: uri,
+        headers: {
+          'BOND-Token': this.bondToken,
+          'Bond-UUID': bondUuid,
+        },
+        data: body,
+        timeout: 10000,
+      }))
       .then(response => {
         this.platform.log.debug(`Response (${bondUuid}) [${method} ${uri}] - ${JSON.stringify(response.data)}`);
         return response.data;
@@ -337,6 +366,9 @@ export class BondApi {
           const message = (error as any).message ?? 'Unknown error';
           this.platform.log.error(`A request error occurred: [code] ${code} [message] ${message}`);
         }
+      })
+      .finally(() => {
+        this.releaseRequestSlot();
       });
   }
 }

--- a/src/interface/Bond.ts
+++ b/src/interface/Bond.ts
@@ -26,7 +26,13 @@ export class Bond {
     private readonly platform: BondPlatform,
     config: BondConfig) {
     this.config = config;
-    this.api = new BondApi(platform, config.token, config.ip_address, config.ms_between_actions);
+    this.api = new BondApi(
+      platform,
+      config.token,
+      config.ip_address,
+      config.ms_between_actions,
+      config.max_concurrent_requests,
+    );
   }
 
   // Helper to sanitze the config object into bond objects

--- a/src/interface/config.ts
+++ b/src/interface/config.ts
@@ -6,6 +6,7 @@ export interface BondConfig {
   token: string;
   hide_device_ids?: string[];
   ms_between_actions?: number;
+  max_concurrent_requests?: number;
 }
 
 export interface BondPlatformConfig extends PlatformConfig {
@@ -105,7 +106,11 @@ export namespace BondConfig {
 
     const validSpaceOutActions = config.ms_between_actions === undefined ||
       (typeof(config.ms_between_actions) === 'number' && Number.isInteger(config.ms_between_actions) && config.ms_between_actions > 0);
+    const validMaxConcurrentRequests = config.max_concurrent_requests === undefined ||
+      (typeof(config.max_concurrent_requests) === 'number'
+        && Number.isInteger(config.max_concurrent_requests)
+        && config.max_concurrent_requests > 0);
 
-    return validIP && validToken && validHideDeviceIds && validSpaceOutActions;
+    return validIP && validToken && validHideDeviceIds && validSpaceOutActions && validMaxConcurrentRequests;
   }
 }

--- a/tests/BondApi.spec.ts
+++ b/tests/BondApi.spec.ts
@@ -15,8 +15,8 @@ function makePlatform() {
   return createMockPlatform() as unknown as BondPlatform;
 }
 
-function makeApi(platform: BondPlatform, ms?: number) {
-  return new BondApi(platform, TEST_TOKEN, TEST_IP, ms);
+function makeApi(platform: BondPlatform, ms?: number, maxConcurrentRequests?: number) {
+  return new BondApi(platform, TEST_TOKEN, TEST_IP, ms, maxConcurrentRequests);
 }
 
 describe('BondApi', () => {
@@ -210,6 +210,41 @@ describe('BondApi', () => {
       const [device] = await api.getDevices(['fan1']);
       expect(device.commands).to.have.length(1);
       expect(device.commands![0].action).to.equal(Action.SetSpeed);
+    });
+
+    it('limits concurrent startup requests', async () => {
+      api = makeApi(platform, undefined, 1);
+      let fan1Returned = false;
+      let fan2StartedBeforeFan1Returned = false;
+
+      nock(`http://${TEST_IP}`)
+        .matchHeader('BOND-Token', TEST_TOKEN)
+        .get('/v2/devices/fan1').reply(async () => {
+          await new Promise(resolve => setTimeout(resolve, 25));
+          fan1Returned = true;
+          return [200, {
+            name: 'Fan 1',
+            type: DeviceType.CeilingFan,
+            location: 'Room',
+            actions: [],
+          }];
+        })
+        .get('/v2/devices/fan1/properties').reply(200, { trust_state: null, max_speed: 6 })
+        .get('/v2/devices/fan2').reply(() => {
+          fan2StartedBeforeFan1Returned = !fan1Returned;
+          return [200, {
+            name: 'Fan 2',
+            type: DeviceType.CeilingFan,
+            location: 'Room',
+            actions: [],
+          }];
+        })
+        .get('/v2/devices/fan2/properties').reply(200, { trust_state: null, max_speed: 6 });
+
+      const devices = await api.getDevices(['fan1', 'fan2']);
+
+      expect(devices).to.have.length(2);
+      expect(fan2StartedBeforeFan1Returned).to.equal(false);
     });
   });
 

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -47,6 +47,16 @@ describe('BondConfig.isValid()', () => {
     expect(valid).to.equal(true);
   });
 
+  it('accepts a positive max_concurrent_requests value', () => {
+    const valid = BondConfig.isValid(platform, {
+      ip_address: '192.168.1.100',
+      token: 'abc123',
+      max_concurrent_requests: 3,
+    });
+
+    expect(valid).to.equal(true);
+  });
+
   it('rejects ip_address values containing a path', () => {
     const valid = BondConfig.isValid(platform, {
       ip_address: '192.168.1.100/v2/devices',
@@ -69,6 +79,26 @@ describe('BondConfig.isValid()', () => {
     const valid = BondConfig.isValid(platform, {
       ip_address: '192.168.1.100#section',
       token: 'abc123',
+    });
+
+    expect(valid).to.equal(false);
+  });
+
+  it('rejects max_concurrent_requests values below 1', () => {
+    const valid = BondConfig.isValid(platform, {
+      ip_address: '192.168.1.100',
+      token: 'abc123',
+      max_concurrent_requests: 0,
+    });
+
+    expect(valid).to.equal(false);
+  });
+
+  it('rejects non-integer max_concurrent_requests values', () => {
+    const valid = BondConfig.isValid(platform, {
+      ip_address: '192.168.1.100',
+      token: 'abc123',
+      max_concurrent_requests: 1.5,
     });
 
     expect(valid).to.equal(false);


### PR DESCRIPTION
## Summary
- Add a small built-in request limiter to `BondApi` so HTTP requests are not all sent to a Bond at once during startup discovery.
- Default each Bond to at most 5 concurrent HTTP requests, with a new per-Bond `max_concurrent_requests` config override for large or sensitive installs.
- Validate and expose the new config option in `config.schema.json`.
- Add regression coverage showing startup device discovery waits when the limit is 1.

## Why
Large Bond/Bond Pro installs can time out during startup because device, property, command-list, and command-detail reads fan out in parallel. Users in #201 observed that requests could time out before reaching the Bond and that limiting request pressure fixed the issue. This reimplements that behavior without adding a new dependency.

Fixes #201

## Validation
- `npm test -- --grep "limits concurrent startup requests|max_concurrent_requests"`
- `npm run build`
- `npm run lint`
- `npm test`