### PR TITLE
chore: bump version to 3.4.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-bond",
-  "version": "3.3.0",
+  "version": "3.4.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-bond",
-      "version": "3.3.0",
+      "version": "3.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "axios": "1.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-bond",
-  "version": "3.3.0",
+  "version": "3.4.0-beta.1",
   "description": "A homebridge plugin to control your Bond devices over the v2 API.",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
Cuts a beta release off main, bundling fixes and improvements that landed since v3.3.0:

- Hardens BPUP setup so UDP send failures no longer crash Homebridge (#302, #303) — addresses #305, where iOS reported "device not compliant" because the bridge was being killed by an uncaught throw in the dgram.send callback.
- Adds optional concurrent-request limiting for the Bond API (#304).
- Adds a Bond simulator test harness and broader stubbed device coverage (#297, #302).
- Adds the bundled Bond OpenAPI 3.0.2 spec under docs/ (#300).
- Reorganizes the Action enum and improves device state handling (#298).
- Patches dependency vulnerabilities (#299).
- Misc simulator-driven Homebridge control-path fixes (#301).