### PR TITLE
fix: auto-reconnect BPUP subscription on socket error or stale connection

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -6,6 +6,24 @@ import { Device } from './interface/Device';
 import { PLUGIN_NAME, PLATFORM_NAME } from './settings';
 import dgram from 'dgram';
 
+// BPUP (Bond Push UDP Protocol) tuning. The Bond acks every keep-alive datagram, so we expect
+// inbound traffic at least once per keep-alive interval. If the socket errors or the connection
+// goes silent past the stale threshold, the subscription has lapsed (e.g. a Wi-Fi/router change)
+// and we transparently re-establish it so state updates resume without a manual restart.
+const BPUP_PORT = 30007;
+const BPUP_KEEPALIVE_MS = 60 * 1000;
+const BPUP_WATCHDOG_INTERVAL_MS = 30 * 1000;
+const BPUP_STALE_THRESHOLD_MS = 150 * 1000;
+const BPUP_RECONNECT_BASE_MS = 2 * 1000;
+const BPUP_RECONNECT_MAX_MS = 60 * 1000;
+
+interface BPUPConnection {
+  socket: dgram.Socket;
+  keepAlive?: ReturnType<typeof setInterval>;
+  watchdog?: ReturnType<typeof setInterval>;
+  reconnectTimer?: ReturnType<typeof setTimeout>;
+}
+
 export class BondPlatform implements DynamicPlatformPlugin {
   public readonly Service: typeof Service = this.api.hap.Service;
   public readonly Characteristic: typeof Characteristic = this.api.hap.Characteristic;
@@ -13,6 +31,7 @@ export class BondPlatform implements DynamicPlatformPlugin {
 
   private accessories: PlatformAccessory[] = [];
   private bonds: Bond[] | undefined;
+  private bpupConnections: Map<string, BPUPConnection> = new Map();
 
   private redactConfig(config: PlatformConfig): PlatformConfig {
     const cast = config as BondPlatformConfig;
@@ -244,30 +263,67 @@ export class BondPlatform implements DynamicPlatformPlugin {
   }
 
   private setupBPUP(bond: Bond) {
-    const PORT = 30007;
+    this.connectBPUP(bond, BPUP_RECONNECT_BASE_MS);
+  }
+
+  // Establishes (or re-establishes) the BPUP subscription for a Bond. The socket auto-recovers
+  // on error or on a stale/silent connection so real-time state updates survive network changes.
+  private connectBPUP(bond: Bond, backoffMs: number) {
     const HOST = this.bpupHost(bond.config.ip_address);
+    const bondId = bond.version?.bondid ?? HOST;
+    const log = this.log;
 
     const message = Buffer.from('');
 
+    // Replace any existing connection for this Bond before creating a new one.
+    this.teardownBPUP(bondId);
+
     const client = dgram.createSocket('udp4');
-    
-    const log = this.log;
+    const connection: BPUPConnection = { socket: client };
+    this.bpupConnections.set(bondId, connection);
+
+    let lastActivity = Date.now();
+    let healthy = false;
+    let reconnectScheduled = false;
+
+    const scheduleReconnect = (reason: string) => {
+      if (reconnectScheduled) {
+        return;
+      }
+      reconnectScheduled = true;
+      // Once a connection has proven healthy, recover quickly; otherwise back off exponentially.
+      const delay = healthy ? BPUP_RECONNECT_BASE_MS : Math.min(backoffMs * 2, BPUP_RECONNECT_MAX_MS);
+      log.warn(`BPUP connection to Bond (${bondId}) lost (${reason}); reconnecting in ${Math.round(delay / 1000)}s.`);
+      this.teardownBPUP(bondId);
+      const reconnectTimer = setTimeout(() => this.connectBPUP(bond, delay), delay);
+      // Track the pending reconnect so a later teardown can cancel it.
+      this.bpupConnections.set(bondId, { socket: client, reconnectTimer });
+    };
 
     function send() {
-      client.send(message, 0, message.length, PORT, HOST, (err: any) => {
+      client.send(message, 0, message.length, BPUP_PORT, HOST, (err: any) => {
         if (err) {
           log.error(`Error sending UDP message: ${err}`);
           return;
         }
-        log.debug(`UDP message sent to ${HOST}:${PORT}`);
+        log.debug(`UDP message sent to ${HOST}:${BPUP_PORT}`);
       });
     }
-    send(); 
-    // From Bond API Docs: The client should continue to send the Keep-Alive datagram on 
+    send();
+    // From Bond API Docs: The client should continue to send the Keep-Alive datagram on
     // the same socket every 60 seconds to keep the connection active.
-    setInterval(send, 1000 * 60);
+    connection.keepAlive = setInterval(send, BPUP_KEEPALIVE_MS);
+    // Watchdog: the Bond acks every keep-alive, so a healthy socket receives traffic well within
+    // the stale threshold. If it goes silent the subscription has lapsed — reconnect to recover.
+    connection.watchdog = setInterval(() => {
+      if (Date.now() - lastActivity > BPUP_STALE_THRESHOLD_MS) {
+        scheduleReconnect('no packets received');
+      }
+    }, BPUP_WATCHDOG_INTERVAL_MS);
 
     client.on('message', (message: Buffer, remote: { address: string; port: string }) => {
+      lastActivity = Date.now();
+      healthy = true;
       const msg = message.toString().trim();
       const packet = this.parseBPUPPacket(msg);
       if (packet) {
@@ -278,9 +334,37 @@ export class BondPlatform implements DynamicPlatformPlugin {
       }
     });
 
-    client.on('close', () => {
-      this.log('Connection closed');
+    client.on('error', (err: Error) => {
+      log.error(`BPUP socket error for Bond (${bondId}): ${err}`);
+      scheduleReconnect('socket error');
     });
+
+    client.on('close', () => {
+      log.debug(`BPUP socket closed for Bond (${bondId}).`);
+    });
+  }
+
+  private teardownBPUP(bondId: string) {
+    const existing = this.bpupConnections.get(bondId);
+    if (!existing) {
+      return;
+    }
+    if (existing.keepAlive) {
+      clearInterval(existing.keepAlive);
+    }
+    if (existing.watchdog) {
+      clearInterval(existing.watchdog);
+    }
+    if (existing.reconnectTimer) {
+      clearTimeout(existing.reconnectTimer);
+    }
+    try {
+      existing.socket.removeAllListeners();
+      existing.socket.close();
+    } catch (_error) {
+      // Socket may already be closed; ignore.
+    }
+    this.bpupConnections.delete(bondId);
   }
 
   private bpupHost(ipAddress: string): string {

--- a/tests/platform.spec.ts
+++ b/tests/platform.spec.ts
@@ -232,4 +232,103 @@ describe('BondPlatform security hardening', () => {
     const udpError = errorCalls.find(args => args[0]?.includes('Error sending UDP message'));
     expect(udpError).to.not.be.undefined;
   });
+
+  it('reconnects the BPUP socket after a socket error', () => {
+    const log = createMockLog();
+    const api = createMockApi() as any;
+    const config = {
+      include_dimmer: false,
+      fan_speed_values: false,
+      include_toggle_state: false,
+      bonds: [{ ip_address: '192.168.1.100', token: 'token' }],
+    } as any;
+
+    const platform = new BondPlatform(log as any, config, api);
+    const handlers: Record<string, (...args: any[]) => void> = {};
+    const fakeSocket = {
+      send: sinon.stub().callsFake((
+        _message: Buffer,
+        _offset: number,
+        _length: number,
+        _port: number,
+        _host: string,
+        callback: (error?: Error) => void,
+      ) => callback()),
+      on: sinon.stub().callsFake((event: string, callback: (...args: any[]) => void) => {
+        handlers[event] = callback;
+      }),
+      removeAllListeners: sinon.stub(),
+      close: sinon.stub(),
+    };
+
+    const createSocket = sinon.stub(dgram, 'createSocket').returns(fakeSocket as any);
+    sinon.stub(global, 'setInterval').returns(1 as any);
+    const setTimeoutStub = sinon.stub(global, 'setTimeout').returns(2 as any);
+    const bond = {
+      version: { bondid: 'ZZBL12345' },
+      config: { ip_address: '192.168.1.100' },
+      receivedBPUPPacket: sinon.stub(),
+    };
+
+    (platform as any).setupBPUP(bond);
+    expect(createSocket.callCount).to.equal(1);
+
+    // Simulate a socket error (e.g. the network dropped out).
+    handlers.error(new Error('ENETUNREACH'));
+
+    const warned = (log.warn.args as string[][]).find(args => args[0]?.includes('reconnecting'));
+    expect(warned, 'should log a reconnect warning').to.not.be.undefined;
+    expect(fakeSocket.close.called, 'should close the failed socket').to.equal(true);
+    expect(setTimeoutStub.called, 'should schedule a reconnect').to.equal(true);
+
+    // Running the scheduled reconnect should establish a fresh socket.
+    const reconnect = setTimeoutStub.firstCall.args[0] as () => void;
+    reconnect();
+    expect(createSocket.callCount).to.equal(2);
+  });
+
+  it('reconnects when the BPUP connection goes stale', () => {
+    const clock = sinon.useFakeTimers();
+    const log = createMockLog();
+    const api = createMockApi() as any;
+    const config = {
+      include_dimmer: false,
+      fan_speed_values: false,
+      include_toggle_state: false,
+      bonds: [{ ip_address: '192.168.1.100', token: 'token' }],
+    } as any;
+
+    const platform = new BondPlatform(log as any, config, api);
+    const fakeSocket = {
+      send: sinon.stub().callsFake((
+        _message: Buffer,
+        _offset: number,
+        _length: number,
+        _port: number,
+        _host: string,
+        callback: (error?: Error) => void,
+      ) => callback()),
+      on: sinon.stub(),
+      removeAllListeners: sinon.stub(),
+      close: sinon.stub(),
+    };
+    const createSocket = sinon.stub(dgram, 'createSocket').returns(fakeSocket as any);
+    const bond = {
+      version: { bondid: 'ZZBL12345' },
+      config: { ip_address: '192.168.1.100' },
+      receivedBPUPPacket: sinon.stub(),
+    };
+
+    (platform as any).setupBPUP(bond);
+    expect(createSocket.callCount).to.equal(1);
+
+    // No inbound packets — advance past the stale threshold so the watchdog reconnects.
+    clock.tick(200 * 1000);
+
+    const warned = (log.warn.args as string[][]).find(args => args[0]?.includes('no packets received'));
+    expect(warned, 'should log a staleness reconnect warning').to.not.be.undefined;
+    expect(createSocket.callCount, 'should re-create the socket').to.be.greaterThan(1);
+
+    clock.restore();
+  });
 });


### PR DESCRIPTION
Related to #192 — a Bond going unresponsive in HomeKit after a router/network reboot and not recovering until Homebridge is manually restarted. This makes the BPUP push subscription re-establish itself automatically after such a disruption.

## Problem

`setupBPUP`'s UDP socket has no error handling or recovery. If the socket errors, or the push subscription silently lapses (for example after a Wi‑Fi/router change or the Bond briefly dropping off the network), real-time BPUP state updates simply stop arriving. HomeKit then shows stale state for the fan/light indefinitely — the only fix is a manual Homebridge restart.

There's also no `error` listener on the socket, so a socket error surfaces as an unhandled `error` event.

## Fix

- Add a socket `error` handler that tears down and re-establishes the BPUP connection, with a small exponential backoff that resets once a connection has proven healthy.
- Add a watchdog that reconnects when no BPUP traffic has been received within a stale threshold. Since the Bond acks every keep-alive datagram, prolonged silence reliably indicates the subscription has lapsed.
- Track each Bond's socket and timers so they're cleaned up on reconnect (this also fixes a pre-existing leak of the keep-alive `setInterval`).

The keep-alive interval (60s) and the receive/parse path are unchanged. New timing constants are conservative (150s stale threshold, 2s→60s backoff).

## Testing

- `npm test` — all passing, including two new tests: reconnect-on-socket-error and reconnect-on-stale-connection.
- `npm run lint` — clean.
- Verified against real hardware (a Smart By Bond Minka Aire fan): forcing a socket error triggers the reconnect and BPUP packets resume arriving on the fresh socket.

